### PR TITLE
Implemented test for getSize() method of FileClientImpl

### DIFF
--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
@@ -1,0 +1,65 @@
+package com.openelements.hiero.base.test;
+
+import com.hedera.hashgraph.sdk.FileId;
+import com.openelements.hiero.base.HieroException;
+import com.openelements.hiero.base.implementation.FileClientImpl;
+import com.openelements.hiero.base.protocol.FileInfoRequest;
+import com.openelements.hiero.base.protocol.FileInfoResponse;
+import com.openelements.hiero.base.protocol.ProtocolLayerClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class FileClientImplTest {
+    ProtocolLayerClient protocolLayerClient;
+    FileClientImpl fileClientImpl;
+
+    @BeforeEach
+    void setup() {
+        protocolLayerClient = Mockito.mock(ProtocolLayerClient.class);
+        fileClientImpl = new FileClientImpl(protocolLayerClient);
+    }
+
+    @Test
+    void testGetFileSize() throws HieroException {
+        // mocks
+        final int size = 10;
+        final FileInfoResponse response = Mockito.mock(FileInfoResponse.class);
+
+        // given
+        final FileId fileId = FileId.fromString("1.2.3");
+
+        // then
+        when(response.size()).thenReturn(size);
+        when(protocolLayerClient.executeFileInfoQuery(any(FileInfoRequest.class)))
+                .thenReturn(response);
+
+        final int result = fileClientImpl.getSize(fileId);
+
+        verify(protocolLayerClient, times(1))
+                .executeFileInfoQuery(any(FileInfoRequest.class));
+        verify(response, times(1)).size();
+        Assertions.assertEquals(size, result);
+    }
+
+    @Test
+    void testGetFileSizeThrowsExceptionForInvalidId() throws HieroException {
+        // given
+        final FileId fileId = FileId.fromString("1.2.3");
+
+        // then
+        when(protocolLayerClient.executeFileInfoQuery(any(FileInfoRequest.class)))
+                .thenThrow(new HieroException("Failed to execute query"));
+
+        Assertions.assertThrows(HieroException.class, () -> fileClientImpl.getSize(fileId));
+    }
+
+    @Test
+    void testGetFileSizeThrowsExceptionForNullId() {
+        Assertions.assertThrows(NullPointerException.class, () -> fileClientImpl.getSize(null));
+    }
+}

--- a/hiero-enterprise-base/src/test/java/module-info.java
+++ b/hiero-enterprise-base/src/test/java/module-info.java
@@ -4,4 +4,5 @@ open module com.openelements.hiero.base.test {
     requires static org.jspecify;
     requires org.junit.jupiter.api;
     requires org.junit.jupiter.params;
+    requires org.mockito;
 }

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FileClientTests.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FileClientTests.java
@@ -27,6 +27,7 @@ public class FileClientTests {
         Assertions.assertThrows(NullPointerException.class, () -> fileClient.deleteFile((String) null));
         Assertions.assertThrows(NullPointerException.class, () -> fileClient.deleteFile((FileId) null));
         Assertions.assertThrows(NullPointerException.class, () -> fileClient.getExpirationTime(null));
+        Assertions.assertThrows(NullPointerException.class, () -> fileClient.getSize(null));
     }
 
     @Test
@@ -239,5 +240,20 @@ public class FileClientTests {
 
         //then
         Assertions.assertArrayEquals(contents, result);
+    }
+
+    @Test
+    void testGetFileSize() throws HieroException {
+        final byte[] contents = "Hello, Hedera!".getBytes();
+        final FileId fileId = fileClient.createFile(contents);
+        final int size = fileClient.getSize(fileId);
+
+        Assertions.assertEquals(size, contents.length);
+    }
+
+    @Test
+    void testGetFileSizeThrowsExceptionForInvalidId() {
+        final FileId invalidFileId = FileId.fromString("1.2.3");
+        Assertions.assertThrows(HieroException.class, () -> fileClient.getSize(invalidFileId));
     }
 }


### PR DESCRIPTION
Implemented test to validate the functionality of the `getSize()` method within the `FileClientImpl` class, covering both successful and failure scenarios.

Closes: #105