### PR TITLE
Implemented tests for missing functionalities in FileClientImpl.createFile()

### DIFF
--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FileClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FileClientImpl.java
@@ -44,7 +44,7 @@ public class FileClientImpl implements FileClient {
 
     private FileId createFileImpl(@NonNull final byte[] contents, @Nullable final Instant expirationTime)
             throws HieroException {
-        Objects.requireNonNull(contents, "fileId must not be null");
+        Objects.requireNonNull(contents, "contents must not be null");
         if (contents.length > FileCreateRequest.FILE_MAX_SIZE) {
             throw new HieroException("File contents must be less than " + FileCreateRequest.FILE_MAX_SIZE + " bytes");
         }

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
@@ -59,9 +59,9 @@ public class FileClientImplTest {
         final FileCreateResult fileCreateResult = Mockito.mock(FileCreateResult.class);
 
         // given
-        byte[] content = new byte[FileCreateRequest.FILE_CREATE_MAX_SIZE * 2];
+        final byte[] content = new byte[FileCreateRequest.FILE_CREATE_MAX_SIZE * 2];
         // -1 because 1 for executeFileCreateTransaction()
-        int appendCount = Math.floorDiv(content.length, FileCreateRequest.FILE_CREATE_MAX_SIZE) - 1;
+        final int appendCount = Math.floorDiv(content.length, FileCreateRequest.FILE_CREATE_MAX_SIZE) - 1;
 
         //then
         when(protocolLayerClient.executeFileCreateTransaction(any(FileCreateRequest.class)))

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FileClientTests.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FileClientTests.java
@@ -7,6 +7,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.IntStream;
+
+import com.openelements.hiero.base.protocol.FileCreateRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -45,7 +47,7 @@ public class FileClientTests {
     @Test
     void testCreateSmallFile() throws Exception {
         //given
-        final byte[] contents = "Hello, Hedera!".getBytes();
+        final byte[] contents = "Hello, Hiero!".getBytes();
 
         //when
         final FileId fileId = fileClient.createFile(contents);
@@ -57,7 +59,7 @@ public class FileClientTests {
     @Test
     void testCreateLargeFile() throws Exception {
         //given
-        final byte[] contents = IntStream.range(0, 500).mapToObj(i -> "Hello, Hedera!")
+        final byte[] contents = IntStream.range(0, 500).mapToObj(i -> "Hello, Hiero!")
                 .reduce((a, b) -> a + b)
                 .get()
                 .getBytes();
@@ -67,6 +69,27 @@ public class FileClientTests {
 
         //then
         Assertions.assertNotNull(fileId);
+    }
+
+    @Test
+    void testCreateFileThrowExceptionIfExceedMaxFileSize() {
+        // given
+        final byte[] contents = new byte[FileCreateRequest.FILE_MAX_SIZE + 1];
+
+        // then
+        Assertions.assertThrows(HieroException.class, () -> fileClient.createFile(contents));
+    }
+
+    @Test
+    void testCreateFileThrowExceptionIfExpirationTimeBeforeNow() {
+        // given
+        final byte[] contents = "Hello Hiero!".getBytes();
+        final Instant definedExpirationTime = Instant.now().minusSeconds(60);
+
+        // then
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> fileClient.createFile(contents, definedExpirationTime)
+        );
     }
 
     @Test


### PR DESCRIPTION
Implemented test to validate the functionality of the `createFile()` method within the `FileClientImpl` class, covering both successful and failure scenarios.

Closes: #99 