### PR TITLE
Implemented Tests for the `AccountClientImpl.createAccount`

### DIFF
--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/AccountClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/AccountClientImpl.java
@@ -24,11 +24,21 @@ public class AccountClientImpl implements AccountClient {
     @NonNull
     @Override
     public Account createAccount(@NonNull Hbar initialBalance) throws HieroException {
-        final AccountCreateRequest request = AccountCreateRequest.of(initialBalance);
-        final AccountCreateResult result = client.executeAccountCreateTransaction(request);
-        return result.newAccount();
+        if (initialBalance == null) {
+            throw new NullPointerException("initialBalance must not be null");
+        }
+        if (initialBalance.toTinybars() < 0) {
+            throw new HieroException("Invalid initial balance: must be non-negative");
+        }
+        try {
+            final AccountCreateRequest request = AccountCreateRequest.of(initialBalance);
+            final AccountCreateResult result = client.executeAccountCreateTransaction(request);
+            return result.newAccount();
+        } catch (IllegalArgumentException e) {
+            throw new HieroException("Invalid initial balance: " + e.getMessage(), e);
+        }
     }
-
+    
     @Override
     public void deleteAccount(@NonNull Account account) throws HieroException {
         final AccountDeleteRequest request = AccountDeleteRequest.of(account);

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FileClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FileClientImpl.java
@@ -152,13 +152,16 @@ public class FileClientImpl implements FileClient {
     }
 
     @Override
-    public boolean isDeleted(@NonNull final FileId fileId) throws HieroException {
-        Objects.requireNonNull(fileId, "fileId must not be null");
-        final FileInfoRequest request = FileInfoRequest.of(fileId);
-        final FileInfoResponse infoResponse = protocolLayerClient.executeFileInfoQuery(request);
-        return infoResponse.deleted();
-    }
+    public boolean isDeleted(FileId fileId) throws HieroException {
+        if (fileId == null) {
+            throw new IllegalArgumentException("fileId must not be null");
+        }
 
+        FileInfoRequest request = FileInfoRequest.of(fileId);
+        FileInfoResponse response = protocolLayerClient.executeFileInfoQuery(request);
+
+        return response.deleted();
+    }
     @Override
     public int getSize(@NonNull final FileId fileId) throws HieroException {
         Objects.requireNonNull(fileId, "fileId must not be null");

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/AccountClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/AccountClientImplTest.java
@@ -3,15 +3,19 @@ package com.openelements.hiero.base.test;
 import com.openelements.hiero.base.implementation.AccountClientImpl;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Hbar;
+import com.openelements.hiero.base.data.Account;
 import com.openelements.hiero.base.HieroException;
 import com.openelements.hiero.base.protocol.AccountBalanceRequest;
 import com.openelements.hiero.base.protocol.AccountBalanceResponse;
+import com.openelements.hiero.base.protocol.AccountCreateRequest;
+import com.openelements.hiero.base.protocol.AccountCreateResult;
 import com.openelements.hiero.base.protocol.ProtocolLayerClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class AccountClientImplTest {
@@ -92,4 +96,61 @@ public class AccountClientImplTest {
             accountClientImpl.getAccountBalance(accountId);
         });
     }
+
+//Tests for createAccount method
+    @Test
+void testCreateAccount_successful() throws HieroException {
+    Hbar initialBalance = Hbar.from(100);
+
+    AccountCreateResult mockResult = mock(AccountCreateResult.class);
+    Account mockAccount = mock(Account.class);
+
+    // Use accountId() instead of getAccountId() because Account is a record.
+    when(mockAccount.accountId()).thenReturn(AccountId.fromString("0.0.12345"));
+
+    when(mockResult.newAccount()).thenReturn(mockAccount);
+    when(mockProtocolLayerClient.executeAccountCreateTransaction(any(AccountCreateRequest.class)))
+        .thenReturn(mockResult);
+
+    Account result = accountClientImpl.createAccount(initialBalance);
+
+    assertNotNull(result);
+    assertEquals(AccountId.fromString("0.0.12345"), result.accountId()); // Use accountId() to get the account ID
+    verify(mockProtocolLayerClient, times(1))
+        .executeAccountCreateTransaction(any(AccountCreateRequest.class));
+}
+
+@Test
+void testCreateAccount_invalidInitialBalance_null() {
+    // Arrange
+    Hbar initialBalance = null;
+
+    // Act & Assert
+    assertThrows(NullPointerException.class, () -> accountClientImpl.createAccount(initialBalance));
+}
+
+@Test
+void testCreateAccount_invalidInitialBalance_negative() {
+    // Arrange
+    Hbar initialBalance = Hbar.from(-100);
+
+    // Act & Assert
+    HieroException exception = assertThrows(
+        HieroException.class,
+        () -> accountClientImpl.createAccount(initialBalance)
+    );
+
+    assertTrue(exception.getMessage().contains("Invalid initial balance"));
+}
+@Test
+void testCreateAccount_hieroExceptionThrown() throws HieroException {
+    // Arrange
+    Hbar initialBalance = Hbar.from(100);
+    when(mockProtocolLayerClient.executeAccountCreateTransaction(any(AccountCreateRequest.class)))
+            .thenThrow(new HieroException("Transaction failed"));
+
+    // Act & Assert
+    Exception exception = assertThrows(HieroException.class, () -> accountClientImpl.createAccount(initialBalance));
+    assertEquals("Transaction failed", exception.getMessage());
+}
 }

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
@@ -1,10 +1,12 @@
 package com.openelements.hiero.base.test;
+
 import com.openelements.hiero.base.implementation.FileClientImpl;
 import com.openelements.hiero.base.HieroException;
 import com.openelements.hiero.base.protocol.FileInfoRequest;
 import com.openelements.hiero.base.protocol.FileInfoResponse;
 import com.openelements.hiero.base.protocol.ProtocolLayerClient;
-import com.hedera.hashgraph.sdk.FileId; 
+import com.hedera.hashgraph.sdk.FileId;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -23,15 +25,16 @@ public class FileClientImplTest {
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.openMocks(this); // Use openMocks() instead of initMocks()
+        MockitoAnnotations.openMocks(this); // Initialize mocks
         fileClient = new FileClientImpl(protocolLayerClient);
     }
 
     @Test
     public void testIsDeleted_FileIsDeleted() throws HieroException {
         // Given
-        FileId fileId = FileId.fromString("0.0.123");  // Correct format
+        FileId fileId = FileId.fromString("0.0.123"); // Correct format
         FileInfoResponse response = mock(FileInfoResponse.class);
+
         when(protocolLayerClient.executeFileInfoQuery(any(FileInfoRequest.class))).thenReturn(response);
         when(response.deleted()).thenReturn(true);
 
@@ -39,14 +42,15 @@ public class FileClientImplTest {
         boolean result = fileClient.isDeleted(fileId);
 
         // Then
-        assertTrue(result);
+        assertTrue(result, "The file should be marked as deleted.");
     }
 
     @Test
     public void testIsDeleted_FileIsNotDeleted() throws HieroException {
         // Given
-        FileId fileId = FileId.fromString("0.0.123");  // Correct format
+        FileId fileId = FileId.fromString("0.0.123"); // Correct format
         FileInfoResponse response = mock(FileInfoResponse.class);
+
         when(protocolLayerClient.executeFileInfoQuery(any(FileInfoRequest.class))).thenReturn(response);
         when(response.deleted()).thenReturn(false);
 
@@ -54,18 +58,35 @@ public class FileClientImplTest {
         boolean result = fileClient.isDeleted(fileId);
 
         // Then
-        assertFalse(result);
+        assertFalse(result, "The file should not be marked as deleted.");
     }
 
     @Test
     public void testIsDeleted_NullFileId() {
         // When
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            fileClient.isDeleted(null); // This should throw an exception
-        });
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> fileClient.isDeleted(null) // Explicitly pass null
+        );
 
         // Then
         assertEquals("fileId must not be null", exception.getMessage());
     }
-}
 
+    @Test
+    public void testIsDeleted_HieroExceptionThrown() throws HieroException {
+        // Given
+        FileId fileId = FileId.fromString("0.0.123");
+        when(protocolLayerClient.executeFileInfoQuery(any(FileInfoRequest.class)))
+                .thenThrow(new HieroException("Error processing request"));
+
+        // When
+        HieroException exception = assertThrows(
+            HieroException.class,
+            () -> fileClient.isDeleted(fileId)
+        );
+
+        // Then
+        assertEquals("Error processing request", exception.getMessage());
+    }
+}

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FileClientImplTest.java
@@ -1,0 +1,71 @@
+package com.openelements.hiero.base.test;
+import com.openelements.hiero.base.implementation.FileClientImpl;
+import com.openelements.hiero.base.HieroException;
+import com.openelements.hiero.base.protocol.FileInfoRequest;
+import com.openelements.hiero.base.protocol.FileInfoResponse;
+import com.openelements.hiero.base.protocol.ProtocolLayerClient;
+import com.hedera.hashgraph.sdk.FileId; 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class FileClientImplTest {
+
+    @Mock
+    private ProtocolLayerClient protocolLayerClient;
+
+    private FileClientImpl fileClient;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this); // Use openMocks() instead of initMocks()
+        fileClient = new FileClientImpl(protocolLayerClient);
+    }
+
+    @Test
+    public void testIsDeleted_FileIsDeleted() throws HieroException {
+        // Given
+        FileId fileId = FileId.fromString("0.0.123");  // Correct format
+        FileInfoResponse response = mock(FileInfoResponse.class);
+        when(protocolLayerClient.executeFileInfoQuery(any(FileInfoRequest.class))).thenReturn(response);
+        when(response.deleted()).thenReturn(true);
+
+        // When
+        boolean result = fileClient.isDeleted(fileId);
+
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsDeleted_FileIsNotDeleted() throws HieroException {
+        // Given
+        FileId fileId = FileId.fromString("0.0.123");  // Correct format
+        FileInfoResponse response = mock(FileInfoResponse.class);
+        when(protocolLayerClient.executeFileInfoQuery(any(FileInfoRequest.class))).thenReturn(response);
+        when(response.deleted()).thenReturn(false);
+
+        // When
+        boolean result = fileClient.isDeleted(fileId);
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsDeleted_NullFileId() {
+        // When
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            fileClient.isDeleted(null); // This should throw an exception
+        });
+
+        // Then
+        assertEquals("fileId must not be null", exception.getMessage());
+    }
+}
+


### PR DESCRIPTION
Created all related test cases to align with the latest method implementation of `createAccount` in `AccountClientImpl`
Updated the `createAccount` method to add explicit validation for initialBalance at the beginning of the method, and throw a HieroException if the balance is invalid: