### PR TITLE
Implemented tests for createAccount method

### DIFF
--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/AccountClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/AccountClientImpl.java
@@ -24,10 +24,23 @@ public class AccountClientImpl implements AccountClient {
     @NonNull
     @Override
     public Account createAccount(@NonNull Hbar initialBalance) throws HieroException {
-        final AccountCreateRequest request = AccountCreateRequest.of(initialBalance);
-        final AccountCreateResult result = client.executeAccountCreateTransaction(request);
-        return result.newAccount();
+        if (initialBalance == null) {
+            throw new NullPointerException("initialBalance must not be null");
+        }
+        
+        if (initialBalance.toTinybars() < 0) {
+            throw new HieroException("Invalid initial balance: must be non-negative");
+        }
+        
+        try {
+            final AccountCreateRequest request = AccountCreateRequest.of(initialBalance);
+            final AccountCreateResult result = client.executeAccountCreateTransaction(request);
+            return result.newAccount();
+        } catch (IllegalArgumentException e) {
+            throw new HieroException("Invalid initial balance: " + e.getMessage(), e);
+        }
     }
+    
 
     @Override
     public void deleteAccount(@NonNull Account account) throws HieroException {

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/AccountClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/AccountClientImpl.java
@@ -37,7 +37,7 @@ public class AccountClientImpl implements AccountClient {
             final AccountCreateResult result = client.executeAccountCreateTransaction(request);
             return result.newAccount();
         } catch (IllegalArgumentException e) {
-            throw new HieroException("Invalid initial balance: " + e.getMessage(), e);
+            throw new HieroException("Error while creating Account", e);
         }
     }
     


### PR DESCRIPTION
Added scenario tests for the `createAccount`. 
Updated the createAccount method to add explicit validation for initialBalance at the beginning of the method, and throw a HieroException if the balance is invalid
