### PR TITLE
feat: Added TopicClient to work with topic

### DIFF
--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
@@ -1,0 +1,320 @@
+package com.openelements.hiero.base;
+
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TopicId;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+/**
+ * Interface for interacting with a Hiero network. This interface provides methods for interacting with Hiero Topic,
+ * like creating, updating and deleting topic. An implementation of this interface is using an internal account to
+ * interact with a Hiero network. That account is the account that is used to pay for the transactions that are sent to
+ * the Hiero network and called 'operator account'.
+ */
+public interface TopicClient {
+    /**
+     * Create a new Topic. The operator account privateKey is used as adminKey for topic.
+     *
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createTopic() throws HieroException;
+
+    /**
+     * Create a new Topic. With an adminKey.
+     *
+     * @param adminKey the adminKey for the topic
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createTopic(@NonNull PrivateKey adminKey) throws HieroException;
+
+    /**
+     * Create a new Topic.
+     *
+     * @param memo the memo for the topic
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createTopic(@NonNull String memo) throws HieroException;
+
+    /**
+     * Create a new Topic.
+     *
+     * @param adminKey the adminKey for the topic
+     * @param memo the memo for the topic
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createTopic(@NonNull PrivateKey adminKey, @NonNull String memo) throws HieroException;
+
+    /**
+     * Create a new private Topic.
+     *
+     * @param submitKey the submitKey for the topic
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createPrivateTopic(@NonNull PrivateKey submitKey) throws HieroException;
+
+    /**
+     * Create a new private Topic.
+     *
+     * @param adminKey the adminKey for the topic
+     * @param submitKey the submitKey for the topic
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createPrivateTopic(@NonNull PrivateKey adminKey, @NonNull PrivateKey submitKey) throws HieroException;
+
+    /**
+     * Create a new private Topic.
+     *
+     * @param submitKey the submitKey for the topic
+     * @param memo the memo for the topic
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createPrivateTopic(@NonNull PrivateKey submitKey, @NonNull String memo) throws HieroException;
+
+    /**
+     * Create a new private Topic.
+     *
+     * @param adminKey the adminKey for the topic
+     * @param submitKey the submitKey for the topic
+     * @param memo the memo for the topic
+     * @return the ID of the new Topic
+     * @throws HieroException if the Topic could not be created
+     */
+    @NonNull
+    TopicId createPrivateTopic(@NonNull PrivateKey adminKey, @NonNull PrivateKey submitKey, @NonNull String memo)
+            throws HieroException;
+
+    /**
+     * Update a Topic. The operator account privateKey is used as adminKey for updating topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param memo the memo for the topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateTopic(@NonNull TopicId topicId, @NonNull String memo) throws HieroException;
+
+    /**
+     * Update a Topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param adminKey the adminKey for topic
+     * @param memo the memo for the topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateTopic(@NonNull TopicId topicId, @NonNull PrivateKey adminKey, @NonNull String memo)
+            throws HieroException;
+
+    /**
+     * Update a Topic. The operator account privateKey is used as adminKey for updating topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param updatedAdminKey the new adminKey for topic
+     * @param submitKey the new submit for topic
+     * @param memo the memo for the topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateTopic(@NonNull TopicId topicId, @NonNull PrivateKey updatedAdminKey, @NonNull PrivateKey submitKey,
+                     @NonNull String memo) throws HieroException;
+
+    /**
+     * Update a Topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param adminKey the adminKey of topic
+     * @param updatedAdminKey the new adminKey for topic
+     * @param submitKey the new submit for topic
+     * @param memo the memo for the topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateTopic(@NonNull TopicId topicId, @NonNull PrivateKey adminKey, @NonNull PrivateKey updatedAdminKey,
+                     @NonNull PrivateKey submitKey, @NonNull String memo) throws HieroException;
+
+    /**
+     * Update adminKey for Topic. The operator account privateKey is used as adminKey for updating topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param updatedAdminKey the new adminKey for topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateAdminKey(@NonNull TopicId topicId, @NonNull PrivateKey updatedAdminKey) throws HieroException;
+
+    /**
+     * Update adminKey for Topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param adminKey the adminKey of topic
+     * @param updatedAdminKey the new adminKey for topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateAdminKey(@NonNull TopicId topicId, @NonNull PrivateKey adminKey, @NonNull PrivateKey updatedAdminKey)
+            throws HieroException;
+
+    /**
+     * Update submitKey for Topic. The operator account privateKey is used as adminKey for updating topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param submitKey the new submitKey for topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateSubmitKey(@NonNull TopicId topicId, @NonNull PrivateKey submitKey) throws HieroException;
+
+    /**
+     * Update submitKey for Topic.
+     *
+     * @param topicId the topicId of topic to update
+     * @param adminKey the adminKey of topic
+     * @param submitKey the new submitKey for topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void updateSubmitKey(@NonNull TopicId topicId, @NonNull PrivateKey adminKey, @NonNull PrivateKey submitKey)
+            throws HieroException;
+
+    /**
+     * Delete a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void deleteTopic(@NonNull TopicId topicId) throws HieroException;
+
+    /**
+     * Delete a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @throws HieroException if the Topic could not be created
+     */
+    default void deleteTopic(@NonNull String topicId) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId cannot be null");
+        deleteTopic(TopicId.fromString(topicId));
+    };
+
+    /**
+     * Delete a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void deleteTopic(@NonNull TopicId topicId, @NonNull PrivateKey adminKey) throws HieroException;
+
+    /**
+     * Delete a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @throws HieroException if the Topic could not be created
+     */
+    default void deleteTopic(@NonNull String topicId, @NonNull String adminKey) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId cannot be null");
+        Objects.requireNonNull(adminKey, "adminKey cannot be null");
+        deleteTopic(TopicId.fromString(topicId), PrivateKey.fromString(adminKey));
+    };
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void submitMessage(@NonNull TopicId topicId, @NonNull byte[] message) throws HieroException;
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    default void submitMessage(@NonNull String topicId, @NonNull byte[] message) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId cannot be null");
+        Objects.requireNonNull(message, "message cannot be null");
+        submitMessage(TopicId.fromString(topicId), message);
+    };
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void submitMessage(@NonNull TopicId topicId, @NonNull String message) throws HieroException;
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    default void submitMessage(@NonNull String topicId, @NonNull String message) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId cannot be null");
+        Objects.requireNonNull(message, "message cannot be null");
+        submitMessage(TopicId.fromString(topicId), message);
+    };
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param submitKey the submit key for submitting message
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void submitMessage(@NonNull TopicId topicId, @NonNull PrivateKey submitKey, @NonNull byte[] message)
+            throws HieroException;
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    default void submitMessage(@NonNull String topicId, @NonNull String submitKey, @NonNull byte[] message)
+            throws HieroException {
+        Objects.requireNonNull(topicId, "topicId cannot be null");
+        Objects.requireNonNull(submitKey, "submitKey cannot be null");
+        Objects.requireNonNull(message, "message cannot be null");
+        submitMessage(TopicId.fromString(topicId), PrivateKey.fromString(submitKey), message);
+    };
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param submitKey the submit key for submitting message
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    void submitMessage(@NonNull TopicId topicId, @NonNull PrivateKey submitKey, @NonNull String message)
+            throws HieroException;
+
+    /**
+     * Submit a message to a Topic.
+     *
+     * @param topicId the topicId of topic
+     * @param message the message to send to topic
+     * @throws HieroException if the Topic could not be created
+     */
+    default void submitMessage(@NonNull String topicId, @NonNull String submitKey, @NonNull String message)
+            throws HieroException {
+        Objects.requireNonNull(topicId, "topicId cannot be null");
+        Objects.requireNonNull(submitKey, "submitKey cannot be null");
+        Objects.requireNonNull(message, "message cannot be null");
+        submitMessage(TopicId.fromString(topicId), PrivateKey.fromString(submitKey), message);
+    };
+}

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
@@ -1,0 +1,205 @@
+package com.openelements.hiero.base.implementation;
+
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.openelements.hiero.base.HieroException;
+import com.openelements.hiero.base.TopicClient;
+import com.openelements.hiero.base.data.Account;
+import com.openelements.hiero.base.protocol.ProtocolLayerClient;
+import com.openelements.hiero.base.protocol.data.*;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public class TopicClientImpl implements TopicClient {
+    private final ProtocolLayerClient client;
+
+    private final Account operationalAccount;
+
+    public TopicClientImpl(@NonNull final ProtocolLayerClient client, @NonNull final Account operationalAccount) {
+        this.client = Objects.requireNonNull(client, "client must not be null");
+        this.operationalAccount = Objects.requireNonNull(operationalAccount, "operationalAccount must not be null");
+    }
+
+    @Override
+    public @NonNull TopicId createTopic() throws HieroException {
+        return createTopic(operationalAccount.privateKey());
+    }
+
+    @Override
+    public @NonNull TopicId createTopic(@NonNull PrivateKey adminKey) throws HieroException {
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        TopicCreateRequest request = TopicCreateRequest.of(adminKey);
+        TopicCreateResult result = client.executeTopicCreateTransaction(request);
+        return result.topicId();
+    }
+
+    @Override
+    public @NonNull TopicId createTopic(@NonNull String memo) throws HieroException {
+        Objects.requireNonNull(memo, "memo must not be null");
+        return createTopic(operationalAccount.privateKey(), memo);
+    }
+
+    @Override
+    public @NonNull TopicId createTopic(@NonNull PrivateKey adminKey, @NonNull String memo) throws HieroException {
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        Objects.requireNonNull(memo, "memo must not be null");
+        TopicCreateRequest request = TopicCreateRequest.of(adminKey, memo);
+        TopicCreateResult result = client.executeTopicCreateTransaction(request);
+        return result.topicId();
+    }
+
+    @Override
+    public @NonNull TopicId createPrivateTopic(@NonNull PrivateKey submitKey) throws HieroException {
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        return createPrivateTopic(operationalAccount.privateKey(), submitKey);
+    }
+
+    @Override
+    public @NonNull TopicId createPrivateTopic(@NonNull PrivateKey adminKey, @NonNull PrivateKey submitKey)
+            throws HieroException {
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        TopicCreateRequest request = TopicCreateRequest.of(adminKey, submitKey);
+        TopicCreateResult result = client.executeTopicCreateTransaction(request);
+        return result.topicId();
+    }
+
+    @Override
+    public @NonNull TopicId createPrivateTopic(@NonNull PrivateKey submitKey, @NonNull String memo)
+            throws HieroException {
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        Objects.requireNonNull(memo, "memo must not be null");
+        return createPrivateTopic(operationalAccount.privateKey(), submitKey, memo);
+    }
+
+    @Override
+    public @NonNull TopicId createPrivateTopic(@NonNull PrivateKey adminKey, @NonNull PrivateKey submitKey,
+                                               @NonNull String memo) throws HieroException {
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        Objects.requireNonNull(memo, "memo must not be null");
+        TopicCreateRequest request = TopicCreateRequest.of(adminKey, submitKey, memo);
+        TopicCreateResult result = client.executeTopicCreateTransaction(request);
+        return result.topicId();
+    }
+
+    @Override
+    public void updateTopic(@NonNull TopicId topicId, @NonNull String memo) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(memo, "memo must not be null");
+        updateTopic(topicId, operationalAccount.privateKey(), memo);
+    }
+
+    @Override
+    public void updateTopic(@NonNull TopicId topicId, @NonNull PrivateKey adminKey, @NonNull String memo)
+            throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        Objects.requireNonNull(memo, "memo must not be null");
+        TopicUpdateRequest request = TopicUpdateRequest.of(topicId, adminKey, memo);
+        client.executeTopicUpdateTransaction(request);
+    }
+
+    @Override
+    public void updateTopic(@NonNull TopicId topicId, @NonNull PrivateKey updatedAdminKey,
+                            @NonNull PrivateKey submitKey, @NonNull String memo) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        Objects.requireNonNull(memo, "memo must not be null");
+       updateTopic(topicId, operationalAccount.privateKey(), updatedAdminKey, submitKey, memo);
+    }
+
+    @Override
+    public void updateTopic(@NonNull TopicId topicId, @NonNull PrivateKey adminKey, @NonNull PrivateKey updatedAdminKey,
+                            @NonNull PrivateKey submitKey, @NonNull String memo) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        Objects.requireNonNull(memo, "memo must not be null");
+        TopicUpdateRequest request = TopicUpdateRequest.of(topicId, adminKey, updatedAdminKey, submitKey, memo);
+        client.executeTopicUpdateTransaction(request);
+    }
+
+    @Override
+    public void updateAdminKey(@NonNull TopicId topicId, @NonNull PrivateKey updatedAdminKey) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(updatedAdminKey, "updatedAdminKey must not be null");
+        updateAdminKey(topicId, operationalAccount.privateKey(), updatedAdminKey);
+    }
+
+    @Override
+    public void updateAdminKey(@NonNull TopicId topicId, @NonNull PrivateKey adminKey,
+                               @NonNull PrivateKey updatedAdminKey) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        Objects.requireNonNull(updatedAdminKey, "updatedAdminKey must not be null");
+        TopicUpdateRequest request = TopicUpdateRequest.updateAdminKey(topicId, adminKey, updatedAdminKey);
+        client.executeTopicUpdateTransaction(request);
+    }
+
+    @Override
+    public void updateSubmitKey(@NonNull TopicId topicId, @NonNull PrivateKey submitKey) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        updateSubmitKey(topicId, operationalAccount.privateKey(), submitKey);
+    }
+
+    @Override
+    public void updateSubmitKey(@NonNull TopicId topicId, @NonNull PrivateKey adminKey, @NonNull PrivateKey submitKey)
+            throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        TopicUpdateRequest request = TopicUpdateRequest.updateSubmitKey(topicId, adminKey, submitKey);
+        client.executeTopicUpdateTransaction(request);
+    }
+
+    @Override
+    public void deleteTopic(@NonNull TopicId topicId) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        TopicDeleteRequest request = TopicDeleteRequest.of(operationalAccount.privateKey(), topicId);
+        client.executeTopicDeleteTransaction(request);
+    }
+
+    @Override
+    public void deleteTopic(@NonNull TopicId topicId, @NonNull PrivateKey adminKey) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(adminKey, "adminKey must not be null");
+        TopicDeleteRequest request = TopicDeleteRequest.of(adminKey, topicId);
+        client.executeTopicDeleteTransaction(request);
+    }
+
+    @Override
+    public void submitMessage(@NonNull TopicId topicId, @NonNull String message) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        submitMessage(topicId, message.getBytes());
+    }
+
+    @Override
+    public void submitMessage(@NonNull TopicId topicId, @NonNull byte[] message) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        TopicSubmitMessageRequest request = TopicSubmitMessageRequest.of(topicId, message);
+        client.executeTopicMessageSubmitTransaction(request);
+    }
+
+    @Override
+    public void submitMessage(@NonNull TopicId topicId, @NonNull PrivateKey submitKey, @NonNull String message) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        submitMessage(topicId, submitKey, message.getBytes());
+    }
+
+    @Override
+    public void submitMessage(@NonNull TopicId topicId, @NonNull PrivateKey submitKey, @NonNull byte[] message)
+            throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(submitKey, "submitKey must not be null");
+        Objects.requireNonNull(message, "message must not be null");
+        TopicSubmitMessageRequest request = TopicSubmitMessageRequest.of(topicId, submitKey, message);
+        client.executeTopicMessageSubmitTransaction(request);
+    }
+}

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/ProtocolLayerClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/ProtocolLayerClient.java
@@ -44,6 +44,8 @@ import com.openelements.hiero.base.protocol.data.TopicMessageRequest;
 import com.openelements.hiero.base.protocol.data.TopicMessageResult;
 import com.openelements.hiero.base.protocol.data.TopicSubmitMessageRequest;
 import com.openelements.hiero.base.protocol.data.TopicSubmitMessageResult;
+import com.openelements.hiero.base.protocol.data.TopicUpdateRequest;
+import com.openelements.hiero.base.protocol.data.TopicUpdateResult;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -235,6 +237,16 @@ public interface ProtocolLayerClient {
      */
     @NonNull
     TopicCreateResult executeTopicCreateTransaction(@NonNull TopicCreateRequest request) throws HieroException;
+
+    /**
+     * Executes a topic update transaction.
+     *
+     * @param request the request containing the details of the topic update transaction
+     * @return the result of the topic update transaction
+     * @throws HieroException if the transaction could not be executed
+     */
+    @NonNull
+    TopicUpdateResult executeTopicUpdateTransaction(@NonNull TopicUpdateRequest request) throws HieroException;
 
     /**
      * Executes a topic delete transaction.

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicCreateRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicCreateRequest.java
@@ -2,25 +2,44 @@ package com.openelements.hiero.base.protocol.data;
 
 import com.hedera.hashgraph.sdk.Hbar;
 import java.time.Duration;
+import java.util.Objects;
+
+import com.hedera.hashgraph.sdk.Key;
+import com.hedera.hashgraph.sdk.PrivateKey;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public record TopicCreateRequest(@NonNull Hbar maxTransactionFee,
-
-                                 @NonNull Duration transactionValidDuration) implements TransactionRequest {
+                                 @NonNull Duration transactionValidDuration,
+                                 @NonNull PrivateKey adminKey,
+                                 @Nullable PrivateKey submitKey,
+                                 @Nullable  String memo) implements TransactionRequest {
 
     public TopicCreateRequest {
-        if (maxTransactionFee == null) {
-            throw new NullPointerException("maxTransactionFee cannot be null");
-        }
-        if (transactionValidDuration == null) {
-            throw new NullPointerException("transactionValidDuration cannot be null");
-        }
+        Objects.requireNonNull(maxTransactionFee,"maxTransactionFee cannot be null");
+        Objects.requireNonNull(transactionValidDuration, "transactionValidDuration cannot be null");
+        Objects.requireNonNull(adminKey, "adminKey cannot be null");
     }
 
-    public static TopicCreateRequest of() {
-        return new TopicCreateRequest(TransactionRequest.DEFAULT_MAX_TRANSACTION_FEE,
-                TransactionRequest.DEFAULT_TRANSACTION_VALID_DURATION);
+    public static TopicCreateRequest of(PrivateKey adminKey) {
+        return of(adminKey, null, null);
     }
 
+    public static TopicCreateRequest of(PrivateKey adminKey, String memo) {
+        return of(adminKey, null, memo);
+    }
 
+    public static TopicCreateRequest of(PrivateKey adminKey, PrivateKey submitKey) {
+        return of(adminKey, submitKey, null);
+    }
+
+    public static TopicCreateRequest of(PrivateKey adminKey, PrivateKey submitKey, String memo) {
+        return new TopicCreateRequest(
+                TransactionRequest.DEFAULT_MAX_TRANSACTION_FEE,
+                TransactionRequest.DEFAULT_TRANSACTION_VALID_DURATION,
+                adminKey,
+                submitKey,
+                memo
+        );
+    }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicCreateResult.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicCreateResult.java
@@ -7,11 +7,11 @@ import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
 public record TopicCreateResult(@NonNull TransactionId transactionId, @NonNull Status status,
-                                @NonNull TopicId fileId) implements TransactionResult {
+                                @NonNull TopicId topicId) implements TransactionResult {
 
     public TopicCreateResult {
         Objects.requireNonNull(transactionId, "transactionId must not be null");
         Objects.requireNonNull(status, "status must not be null");
-        Objects.requireNonNull(fileId, "fileId must not be null");
+        Objects.requireNonNull(topicId, "topicId must not be null");
     }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicDeleteRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicDeleteRequest.java
@@ -1,22 +1,24 @@
 package com.openelements.hiero.base.protocol.data;
 
 import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.TopicId;
 import java.time.Duration;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
-public record TopicDeleteRequest(Hbar maxTransactionFee,
-
-                                 Duration transactionValidDuration,
-
+public record TopicDeleteRequest(@NonNull Hbar maxTransactionFee,
+                                 @NonNull Duration transactionValidDuration,
+                                 @NonNull PrivateKey adminKey,
                                  @NonNull TopicId topicId) implements TransactionRequest {
 
     public TopicDeleteRequest {
-        Objects.requireNonNull(topicId, "TopicId cannot be null");
+        Objects.requireNonNull(maxTransactionFee,"maxTransactionFee cannot be null");
+        Objects.requireNonNull(transactionValidDuration, "transactionValidDuration cannot be null");
+        Objects.requireNonNull(topicId, "topicId cannot be null");
     }
 
-    public static TopicDeleteRequest of(@NonNull final TopicId topicId) {
-        return new TopicDeleteRequest(DEFAULT_MAX_TRANSACTION_FEE, DEFAULT_TRANSACTION_VALID_DURATION, topicId);
+    public static TopicDeleteRequest of(@NonNull PrivateKey adminKey, @NonNull final TopicId topicId) {
+        return new TopicDeleteRequest(DEFAULT_MAX_TRANSACTION_FEE, DEFAULT_TRANSACTION_VALID_DURATION, adminKey, topicId);
     }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicSubmitMessageRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicSubmitMessageRequest.java
@@ -1,15 +1,18 @@
 package com.openelements.hiero.base.protocol.data;
 
 import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.TopicId;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public record TopicSubmitMessageRequest(Hbar maxTransactionFee,
                                         Duration transactionValidDuration,
                                         @NonNull TopicId topicId,
+                                        @Nullable PrivateKey submitKey,
                                         @NonNull byte[] message) implements TransactionRequest {
 
     static final int MAX_MESSAGE_LENGTH = 1024;
@@ -22,14 +25,26 @@ public record TopicSubmitMessageRequest(Hbar maxTransactionFee,
         }
     }
 
-    public static TopicSubmitMessageRequest of(@NonNull final TopicId topicId, @NonNull final String message) {
+    public static TopicSubmitMessageRequest of(@NonNull final TopicId topicId,  @NonNull final String message) {
+        Objects.requireNonNull(message, "Message cannot be null");
+        return of(topicId, null, message);
+    }
+
+    public static TopicSubmitMessageRequest of(@NonNull final TopicId topicId,  @NonNull final byte[] message) {
+        Objects.requireNonNull(message, "Message cannot be null");
+        return of(topicId, null, message);
+    }
+
+    public static TopicSubmitMessageRequest of(@NonNull final TopicId topicId, @Nullable PrivateKey submitKey, @NonNull final String message) {
         Objects.requireNonNull(message, "Message cannot be null");
         return new TopicSubmitMessageRequest(DEFAULT_MAX_TRANSACTION_FEE, DEFAULT_TRANSACTION_VALID_DURATION, topicId,
+                submitKey,
                 message.getBytes(StandardCharsets.UTF_8));
     }
 
-    public static TopicSubmitMessageRequest of(@NonNull final TopicId topicId, @NonNull final byte[] message) {
+    public static TopicSubmitMessageRequest of(@NonNull final TopicId topicId, @Nullable PrivateKey submitKey, @NonNull final byte[] message) {
         return new TopicSubmitMessageRequest(DEFAULT_MAX_TRANSACTION_FEE, DEFAULT_TRANSACTION_VALID_DURATION, topicId,
+                submitKey,
                 message);
     }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicUpdateRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicUpdateRequest.java
@@ -1,0 +1,53 @@
+package com.openelements.hiero.base.protocol.data;
+
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TopicId;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public record TopicUpdateRequest(@NonNull Hbar maxTransactionFee,
+                                 @NonNull Duration transactionValidDuration,
+                                 @NonNull TopicId topicId,
+                                 @NonNull PrivateKey adminKey,
+                                 @Nullable PrivateKey updatedAdminKey,
+                                 @Nullable PrivateKey submitKey,
+                                 @Nullable String memo) implements TransactionRequest {
+    public TopicUpdateRequest{
+        Objects.requireNonNull(maxTransactionFee,"maxTransactionFee cannot be null");
+        Objects.requireNonNull(transactionValidDuration, "transactionValidDuration cannot be null");
+        Objects.requireNonNull(topicId,"topicId cannot be null");
+        Objects.requireNonNull(adminKey, "adminKey cannot be null");
+    }
+
+    public static TopicUpdateRequest of(TopicId topicId, PrivateKey adminKey, String memo) {
+        return of(topicId, adminKey, null, null, memo);
+    }
+
+    public static TopicUpdateRequest of(TopicId topicId, PrivateKey adminKey, PrivateKey updatedAdminKey, PrivateKey submitKey) {
+        return of(topicId, adminKey, updatedAdminKey, submitKey, null);
+    }
+
+    public static TopicUpdateRequest updateAdminKey(TopicId topicId, PrivateKey adminKey, PrivateKey updatedAdminKey) {
+        return of(topicId, adminKey, updatedAdminKey, null, null);
+    }
+
+    public static TopicUpdateRequest updateSubmitKey(TopicId topicId, PrivateKey adminKey, PrivateKey submitKey) {
+        return of(topicId, adminKey, null, submitKey, null);
+    }
+
+    public static TopicUpdateRequest of(TopicId topicId, PrivateKey adminKey, PrivateKey updatedAdminKey, PrivateKey submitKey, String memo) {
+        return new TopicUpdateRequest(
+                TransactionRequest.DEFAULT_MAX_TRANSACTION_FEE,
+                TransactionRequest.DEFAULT_TRANSACTION_VALID_DURATION,
+                topicId,
+                adminKey,
+                updatedAdminKey,
+                submitKey,
+                memo
+        );
+    }
+}

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicUpdateResult.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicUpdateResult.java
@@ -1,0 +1,15 @@
+package com.openelements.hiero.base.protocol.data;
+
+import com.hedera.hashgraph.sdk.Status;
+import com.hedera.hashgraph.sdk.TransactionId;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public record TopicUpdateResult(@NonNull TransactionId transactionId,
+                                @NonNull Status status) implements TransactionResult {
+    public TopicUpdateResult {
+        Objects.requireNonNull(transactionId, "transactionId must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+    }
+}

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerDataCreationTests.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerDataCreationTests.java
@@ -54,6 +54,8 @@ import com.openelements.hiero.base.protocol.data.TopicSubmitMessageResult;
 import com.openelements.hiero.base.protocol.data.TopicSubmitMessageRequest;
 import com.openelements.hiero.base.protocol.data.TopicDeleteRequest;
 import com.openelements.hiero.base.protocol.data.TopicCreateRequest;
+import com.openelements.hiero.base.protocol.data.TopicUpdateRequest;
+import com.openelements.hiero.base.protocol.data.TopicUpdateResult;
 
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
@@ -233,11 +235,55 @@ public class ProtocolLayerDataCreationTests {
         //given
         final Hbar validMaxTransactionFee = Hbar.fromTinybars(1000);
         final Duration validTransactionDuration = Duration.ofSeconds(120);
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
 
-        Assertions.assertDoesNotThrow(() -> new TopicCreateRequest(validMaxTransactionFee, validTransactionDuration));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> new TopicCreateRequest(null, validTransactionDuration));
-        Assertions.assertThrows(NullPointerException.class, () -> new TopicCreateRequest(validMaxTransactionFee, null));
+        Assertions.assertDoesNotThrow(() -> new TopicCreateRequest(
+                validMaxTransactionFee, validTransactionDuration, adminKey, null, null));
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new TopicCreateRequest(null, null, adminKey, null, null)
+        );
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new TopicCreateRequest(null, validTransactionDuration, null, null, null)
+        );
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new TopicCreateRequest(validMaxTransactionFee, null, null, null, null)
+        );
+    }
+
+    @Test
+    void testTopicUpdateRequestCreation() {
+        //given
+        final Hbar validMaxTransactionFee = Hbar.fromTinybars(1000);
+        final Duration validTransactionDuration = Duration.ofSeconds(120);
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicId topicId = TopicId.fromString("1.2.3");
+
+
+        Assertions.assertDoesNotThrow(() -> new TopicUpdateRequest(
+                validMaxTransactionFee, validTransactionDuration, topicId, adminKey, null, null, null));
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new TopicUpdateRequest(
+                        validMaxTransactionFee, null, null, null, null, null, null)
+        );
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new TopicUpdateRequest(
+                        null, validTransactionDuration, null, null, null, null, null)
+        );
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new TopicUpdateRequest(
+                        null, null, topicId, null, null, null, null)
+        );
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> new TopicUpdateRequest(
+                        null, null, null, adminKey, null, null, null)
+        );
     }
 
     @Test
@@ -1032,7 +1078,7 @@ public class ProtocolLayerDataCreationTests {
         Assertions.assertDoesNotThrow(() -> TopicSubmitMessageRequest.of(validTopicId, validMessage));
         Assertions.assertDoesNotThrow(() -> TopicSubmitMessageRequest.of(validTopicId, validMessageBytes));
         Assertions.assertDoesNotThrow(
-                () -> new TopicSubmitMessageRequest(validMaxTransactionFee, validTransactionValidDuration, validTopicId,
+                () -> new TopicSubmitMessageRequest(validMaxTransactionFee, validTransactionValidDuration, validTopicId, null,
                         validMessage.getBytes(StandardCharsets.UTF_8)));
         Assertions.assertThrows(NullPointerException.class, () -> TopicSubmitMessageRequest.of(null, validMessage));
         Assertions.assertThrows(NullPointerException.class,
@@ -1043,10 +1089,10 @@ public class ProtocolLayerDataCreationTests {
                 () -> TopicSubmitMessageRequest.of(validTopicId, largeMessage));
         Assertions.assertThrows(NullPointerException.class,
                 () -> new TopicSubmitMessageRequest(validMaxTransactionFee, validTransactionValidDuration, null,
-                        validMessage.getBytes(StandardCharsets.UTF_8)));
+                       null , validMessage.getBytes(StandardCharsets.UTF_8)));
         Assertions.assertThrows(NullPointerException.class,
                 () -> new TopicSubmitMessageRequest(validMaxTransactionFee, validTransactionValidDuration, validTopicId,
-                        null));
+                        null, null));
     }
 
     @Test
@@ -1056,22 +1102,21 @@ public class ProtocolLayerDataCreationTests {
         final Duration transactionValidDuration = Duration.ofSeconds(10);
         final String topicIdString = "0.0.12345";
         final TopicId topicId = TopicId.fromString(topicIdString);
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
 
         //then
-        Assertions.assertDoesNotThrow(() -> TopicDeleteRequest.of(topicId));
-        Assertions.assertDoesNotThrow(
-                () -> new TopicDeleteRequest(maxTransactionFee, transactionValidDuration, topicId));
-        Assertions.assertDoesNotThrow(() -> new TopicDeleteRequest(null, transactionValidDuration, topicId));
-        Assertions.assertDoesNotThrow(() -> new TopicDeleteRequest(maxTransactionFee, null, topicId));
-        Assertions.assertDoesNotThrow(() -> new TopicDeleteRequest(null, null, topicId));
-        Assertions.assertThrows(NullPointerException.class, () -> TopicDeleteRequest.of(null));
+        Assertions.assertDoesNotThrow(() -> TopicDeleteRequest.of(adminKey,topicId));
+        Assertions.assertDoesNotThrow(() -> new TopicDeleteRequest(maxTransactionFee, transactionValidDuration, adminKey, topicId));
+
+        Assertions.assertThrows(NullPointerException.class, () -> TopicDeleteRequest.of(null, null));
         Assertions.assertThrows(NullPointerException.class,
-                () -> new TopicDeleteRequest(maxTransactionFee, transactionValidDuration, null));
+                () -> new TopicDeleteRequest(maxTransactionFee, null, null, null));
         Assertions.assertThrows(NullPointerException.class,
-                () -> new TopicDeleteRequest(null, transactionValidDuration, null));
+                () -> new TopicDeleteRequest(null, transactionValidDuration, null, null));
         Assertions.assertThrows(NullPointerException.class,
-                () -> new TopicDeleteRequest(maxTransactionFee, null, null));
-        Assertions.assertThrows(NullPointerException.class, () -> new TopicDeleteRequest(null, null, null));
+                () -> new TopicDeleteRequest(null, null, adminKey, null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new TopicDeleteRequest(null, null, null, topicId));
     }
 
     @Test
@@ -1089,5 +1134,19 @@ public class ProtocolLayerDataCreationTests {
                 () -> new TopicCreateResult(validTransactionId, null, validTopicId));
         Assertions.assertThrows(NullPointerException.class,
                 () -> new TopicCreateResult(validTransactionId, validStatus, null));
+    }
+
+    @Test
+    void testTopicUpdateResultCreation() {
+        //given
+        final TransactionId validTransactionId = TransactionId.fromString("0.0.123451@1697590800.123456789");
+        final Status validStatus = Status.SUCCESS;
+
+        //then
+        Assertions.assertDoesNotThrow(() -> new TopicUpdateResult(validTransactionId, validStatus));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new TopicUpdateResult(null, validStatus));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new TopicUpdateResult(validTransactionId, null));
     }
 }

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/TopicClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/TopicClientImplTest.java
@@ -1,0 +1,590 @@
+package com.openelements.hiero.base.test;
+
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.openelements.hiero.base.HieroException;
+import com.openelements.hiero.base.data.Account;
+import com.openelements.hiero.base.implementation.TopicClientImpl;
+import com.openelements.hiero.base.protocol.ProtocolLayerClient;
+import com.openelements.hiero.base.protocol.data.TopicCreateRequest;
+import com.openelements.hiero.base.protocol.data.TopicCreateResult;
+import com.openelements.hiero.base.protocol.data.TopicUpdateRequest;
+import com.openelements.hiero.base.protocol.data.TopicUpdateResult;
+import com.openelements.hiero.base.protocol.data.TopicDeleteRequest;
+import com.openelements.hiero.base.protocol.data.TopicDeleteResult;
+import com.openelements.hiero.base.protocol.data.TopicSubmitMessageRequest;
+import com.openelements.hiero.base.protocol.data.TopicSubmitMessageResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class TopicClientImplTest {
+    ProtocolLayerClient protocolLayerClient;
+    Account operationalAccount;
+
+    TopicClientImpl topicClient;
+
+    ArgumentCaptor<TopicCreateRequest> topicCreateCaptor = ArgumentCaptor.forClass(TopicCreateRequest.class);
+    ArgumentCaptor<TopicUpdateRequest> topicUpdateCaptor = ArgumentCaptor.forClass(TopicUpdateRequest.class);
+    ArgumentCaptor<TopicDeleteRequest> topicDeleteCaptor = ArgumentCaptor.forClass(TopicDeleteRequest.class);
+    ArgumentCaptor<TopicSubmitMessageRequest> topicSubmitCaptor = ArgumentCaptor.forClass(TopicSubmitMessageRequest.class);
+
+    @BeforeEach
+    void setup() {
+        protocolLayerClient = Mockito.mock(ProtocolLayerClient.class);
+        operationalAccount = Mockito.mock(Account.class);
+        topicClient = new TopicClientImpl(protocolLayerClient, operationalAccount);
+    }
+
+    @Test
+    void shouldCreateTopicWithOperationalAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicCreateResult topicCreateResult = Mockito.mock(TopicCreateResult.class);
+        final TopicId topicId = TopicId.fromString("1.2.3");
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicCreateTransaction(any(TopicCreateRequest.class)))
+                .thenReturn(topicCreateResult);
+        when(topicCreateResult.topicId()).thenReturn(topicId);
+        final TopicId result = topicClient.createTopic();
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicCreateTransaction(topicCreateCaptor.capture());
+        verify(topicCreateResult, times(1)).topicId();
+
+        final TopicCreateRequest request = topicCreateCaptor.getValue();
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertNull(request.memo());
+        Assertions.assertNull(request.submitKey());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(topicId, result);
+    }
+
+    @Test
+    void shouldCreateTopicWithMemoAndOperationalAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicCreateResult topicCreateResult = Mockito.mock(TopicCreateResult.class);
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final String memo = "Hello Hiero";
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicCreateTransaction(any(TopicCreateRequest.class)))
+                .thenReturn(topicCreateResult);
+        when(topicCreateResult.topicId()).thenReturn(topicId);
+        final TopicId result = topicClient.createTopic(memo);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicCreateTransaction(topicCreateCaptor.capture());
+        verify(topicCreateResult, times(1)).topicId();
+
+        final TopicCreateRequest request = topicCreateCaptor.getValue();
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(memo, request.memo());
+        Assertions.assertNull(request.submitKey());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(topicId, result);
+    }
+
+    @Test
+    void shouldCreateTopicForGivenAdminKey() throws HieroException {
+        // mock
+        final TopicCreateResult topicCreateResult = Mockito.mock(TopicCreateResult.class);
+        final TopicId topicId = TopicId.fromString("1.2.3");
+
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        // when
+        when(protocolLayerClient.executeTopicCreateTransaction(any(TopicCreateRequest.class)))
+                .thenReturn(topicCreateResult);
+        when(topicCreateResult.topicId()).thenReturn(topicId);
+        final TopicId result = topicClient.createTopic(adminKey);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicCreateTransaction(topicCreateCaptor.capture());
+        verify(topicCreateResult, times(1)).topicId();
+
+        final TopicCreateRequest request = topicCreateCaptor.getValue();
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertNull(request.submitKey());
+        Assertions.assertNull(request.memo());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(topicId, result);
+    }
+
+    @Test
+    void shouldThrowExceptionForNullParamDuringCreateTopic() {
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.createTopic(null, null));
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.createTopic((String) null));
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.createTopic((PrivateKey) null));
+    }
+
+    @Test
+    void shouldCreatePrivateTopicWithOperationalAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicCreateResult topicCreateResult = Mockito.mock(TopicCreateResult.class);
+        final TopicId topicId = TopicId.fromString("1.2.3");
+
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicCreateTransaction(any(TopicCreateRequest.class)))
+                .thenReturn(topicCreateResult);
+        when(topicCreateResult.topicId()).thenReturn(topicId);
+        final TopicId result = topicClient.createPrivateTopic(submitKey);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicCreateTransaction(topicCreateCaptor.capture());
+        verify(topicCreateResult, times(1)).topicId();
+
+        final TopicCreateRequest request = topicCreateCaptor.getValue();
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(submitKey, request.submitKey());
+        Assertions.assertNull(request.memo());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(topicId, result);
+    }
+
+    @Test
+    void shouldCreatePrivateTopicWithMemoAndOperationalAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicCreateResult topicCreateResult = Mockito.mock(TopicCreateResult.class);
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final String memo = "Hello Hiero";
+
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicCreateTransaction(any(TopicCreateRequest.class)))
+                .thenReturn(topicCreateResult);
+        when(topicCreateResult.topicId()).thenReturn(topicId);
+        final TopicId result = topicClient.createPrivateTopic(submitKey, memo);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicCreateTransaction(topicCreateCaptor.capture());
+        verify(topicCreateResult, times(1)).topicId();
+
+        final TopicCreateRequest request = topicCreateCaptor.getValue();
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(submitKey, request.submitKey());
+        Assertions.assertEquals(memo, request.memo());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(topicId, result);
+    }
+
+    @Test
+    void shouldCreatePrivateTopicForGivenAdminKey() throws HieroException {
+        // mock
+        final TopicCreateResult topicCreateResult = Mockito.mock(TopicCreateResult.class);
+        final TopicId topicId = TopicId.fromString("1.2.3");
+
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        // when
+        when(protocolLayerClient.executeTopicCreateTransaction(any(TopicCreateRequest.class)))
+                .thenReturn(topicCreateResult);
+        when(topicCreateResult.topicId()).thenReturn(topicId);
+        final TopicId result = topicClient.createPrivateTopic(adminKey, submitKey);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicCreateTransaction(topicCreateCaptor.capture());
+        verify(topicCreateResult, times(1)).topicId();
+
+        final TopicCreateRequest request = topicCreateCaptor.getValue();
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(submitKey, request.submitKey());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(topicId, result);
+    }
+
+    @Test
+    void shouldThrowExceptionForNullParamDuringCreatePrivateTopic() {
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.createPrivateTopic(null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.createPrivateTopic(null, (PrivateKey) null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.createPrivateTopic(null, null, null));
+    }
+
+    @Test
+    void shouldUpdateTopicAllPropertiesAndUseOperatorAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicUpdateResult topicUpdateResult = Mockito.mock(TopicUpdateResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final String memo = "Hello Hiero";
+        final PrivateKey updatedAdminKey = PrivateKey.generateECDSA();
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicUpdateTransaction(any(TopicUpdateRequest.class)))
+                .thenReturn(topicUpdateResult);
+        topicClient.updateTopic(topicId, updatedAdminKey, submitKey, memo);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicUpdateTransaction(topicUpdateCaptor.capture());
+
+        final TopicUpdateRequest request = topicUpdateCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(updatedAdminKey, request.updatedAdminKey());
+        Assertions.assertEquals(submitKey, request.submitKey());
+        Assertions.assertEquals(memo, request.memo());
+    }
+
+    @Test
+    void shouldUpdateTopicMemoAndUseOperatorAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicUpdateResult topicUpdateResult = Mockito.mock(TopicUpdateResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final String memo = "Updated Hello Hiero";
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicUpdateTransaction(any(TopicUpdateRequest.class)))
+                .thenReturn(topicUpdateResult);
+        topicClient.updateTopic(topicId,memo);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicUpdateTransaction(topicUpdateCaptor.capture());
+
+        final TopicUpdateRequest request = topicUpdateCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(memo, request.memo());
+        Assertions.assertNull(request.updatedAdminKey());
+        Assertions.assertNull(request.submitKey());
+    }
+
+    @Test
+    void shouldUpdateTopicAllPropertiesForGivenAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicUpdateResult topicUpdateResult = Mockito.mock(TopicUpdateResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final String memo = "Hello Hiero";
+        final PrivateKey updatedAdminKey = PrivateKey.generateECDSA();
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(protocolLayerClient.executeTopicUpdateTransaction(any(TopicUpdateRequest.class)))
+                .thenReturn(topicUpdateResult);
+        topicClient.updateTopic(topicId, adminKey, updatedAdminKey, submitKey, memo);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicUpdateTransaction(topicUpdateCaptor.capture());
+
+        final TopicUpdateRequest request = topicUpdateCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(updatedAdminKey, request.updatedAdminKey());
+        Assertions.assertEquals(submitKey, request.submitKey());
+        Assertions.assertEquals(memo, request.memo());
+    }
+
+    @Test
+    void shouldThrowExceptionForNullParamOnUpdateTopic() throws HieroException {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.updateTopic(null, null, null, null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.updateTopic(null, null, null));
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.updateTopic(null, null));
+    }
+
+    @Test
+    void shouldUpdateAdminKeyAndUseOperatorAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicUpdateResult topicUpdateResult = Mockito.mock(TopicUpdateResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey updatedAdminKey = PrivateKey.generateECDSA();
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicUpdateTransaction(any(TopicUpdateRequest.class)))
+                .thenReturn(topicUpdateResult);
+        topicClient.updateAdminKey(topicId, updatedAdminKey);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicUpdateTransaction(topicUpdateCaptor.capture());
+
+        final TopicUpdateRequest request = topicUpdateCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(updatedAdminKey, request.updatedAdminKey());
+        Assertions.assertNull(request.submitKey());
+        Assertions.assertNull(request.memo());
+    }
+
+    @Test
+    void shouldUpdateAdminKeyForGivenAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicUpdateResult topicUpdateResult = Mockito.mock(TopicUpdateResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey updatedAdminKey = PrivateKey.generateECDSA();
+
+        // when
+        when(protocolLayerClient.executeTopicUpdateTransaction(any(TopicUpdateRequest.class)))
+                .thenReturn(topicUpdateResult);
+        topicClient.updateAdminKey(topicId, adminKey, updatedAdminKey);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicUpdateTransaction(topicUpdateCaptor.capture());
+
+        final TopicUpdateRequest request = topicUpdateCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(updatedAdminKey, request.updatedAdminKey());
+        Assertions.assertNull(request.submitKey());
+        Assertions.assertNull(request.memo());
+    }
+
+    @Test
+    void shouldThrowExceptionForNullParamOnUpdateAdminKey() throws HieroException {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.updateAdminKey(null, null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.updateAdminKey(null, null, null));
+    }
+
+    @Test
+    void shouldUpdateSubmitKeyAndUseOperatorAccountPrivateKeyAsAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicUpdateResult topicUpdateResult = Mockito.mock(TopicUpdateResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicUpdateTransaction(any(TopicUpdateRequest.class)))
+                .thenReturn(topicUpdateResult);
+        topicClient.updateSubmitKey(topicId, submitKey);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicUpdateTransaction(topicUpdateCaptor.capture());
+
+        final TopicUpdateRequest request = topicUpdateCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(submitKey, request.submitKey());
+        Assertions.assertNull(request.updatedAdminKey());
+        Assertions.assertNull(request.memo());
+    }
+
+    @Test
+    void shouldUpdateSubmitKeyForGivenAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicUpdateResult topicUpdateResult = Mockito.mock(TopicUpdateResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(protocolLayerClient.executeTopicUpdateTransaction(any(TopicUpdateRequest.class)))
+                .thenReturn(topicUpdateResult);
+        topicClient.updateSubmitKey(topicId, adminKey, submitKey);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicUpdateTransaction(topicUpdateCaptor.capture());
+
+        final TopicUpdateRequest request = topicUpdateCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+        Assertions.assertEquals(submitKey, request.submitKey());
+        Assertions.assertNull(request.updatedAdminKey());
+        Assertions.assertNull(request.memo());
+    }
+
+    @Test
+    void shouldThrowExceptionForNullParamOnUpdateSubmitKey() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.updateSubmitKey(null, null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> topicClient.updateSubmitKey(null, null, null));
+    }
+
+    @Test
+    void shouldDeleteTopicAndUseDefaultAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicDeleteResult topicDeleteResult = Mockito.mock(TopicDeleteResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(operationalAccount.privateKey()).thenReturn(adminKey);
+        when(protocolLayerClient.executeTopicDeleteTransaction(any(TopicDeleteRequest.class)))
+                .thenReturn(topicDeleteResult);
+        topicClient.deleteTopic(topicId);
+
+        // then
+        verify(operationalAccount, times(1)).privateKey();
+        verify(protocolLayerClient, times(1))
+                .executeTopicDeleteTransaction(topicDeleteCaptor.capture());
+
+        final TopicDeleteRequest request = topicDeleteCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+    }
+
+    @Test
+    void shouldDeleteTopicAndUseGivenAdminKey() throws HieroException {
+        // mock
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicDeleteResult topicDeleteResult = Mockito.mock(TopicDeleteResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+
+        // when
+        when(protocolLayerClient.executeTopicDeleteTransaction(any(TopicDeleteRequest.class)))
+                .thenReturn(topicDeleteResult);
+        topicClient.deleteTopic(topicId, adminKey);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicDeleteTransaction(topicDeleteCaptor.capture());
+
+        final TopicDeleteRequest request = topicDeleteCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(adminKey, request.adminKey());
+    }
+
+    @Test
+    void shouldThrowExceptionForNullParamOnUpdateDeleteTopic() {
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.deleteTopic((TopicId) null));
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.deleteTopic((TopicId) null, null));
+    }
+
+    @Test
+    void shouldSubmitMessageToTopic() throws HieroException {
+        // mock
+        final TopicSubmitMessageResult topicSubmitMessageResult = Mockito.mock(TopicSubmitMessageResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final byte[] message = "Hello Hiero".getBytes();
+
+        // when
+        when(protocolLayerClient.executeTopicMessageSubmitTransaction(any(TopicSubmitMessageRequest.class)))
+                .thenReturn(topicSubmitMessageResult);
+        topicClient.submitMessage(topicId, message);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicMessageSubmitTransaction(topicSubmitCaptor.capture());
+
+        final TopicSubmitMessageRequest request = topicSubmitCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(message, request.message());
+        Assertions.assertNull(request.submitKey());
+    }
+
+    @Test
+    void shouldSubmitMessageToPrivateTopic() throws HieroException {
+        // mock
+        final TopicSubmitMessageResult topicSubmitMessageResult = Mockito.mock(TopicSubmitMessageResult.class);
+
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        final byte[] message = "Hello Hiero".getBytes();
+
+        // when
+        when(protocolLayerClient.executeTopicMessageSubmitTransaction(any(TopicSubmitMessageRequest.class)))
+                .thenReturn(topicSubmitMessageResult);
+        topicClient.submitMessage(topicId, submitKey, message);
+
+        // then
+        verify(protocolLayerClient, times(1))
+                .executeTopicMessageSubmitTransaction(topicSubmitCaptor.capture());
+
+        final TopicSubmitMessageRequest request = topicSubmitCaptor.getValue();
+        Assertions.assertEquals(topicId, request.topicId());
+        Assertions.assertEquals(message, request.message());
+        Assertions.assertEquals(submitKey, request.submitKey());
+    }
+
+    @Test
+    void shouldThrowExceptionIfMessageGreaterThanMaxLenOnSubmitMessage() throws HieroException {
+        final String e_message = "Message cannot be longer than 1024 bytes";
+        // given
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        final byte[] message = new byte[1025];
+
+        // then
+        final IllegalArgumentException e1 = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> topicClient.submitMessage(topicId, message));
+        final IllegalArgumentException e2 = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> topicClient.submitMessage(topicId, submitKey, message));
+
+        Assertions.assertEquals(e_message, e1.getMessage());
+        Assertions.assertEquals(e_message, e2.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionForNullParamOnSubmitMessage() {
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.submitMessage((TopicId) null, (String)null));
+        Assertions.assertThrows(NullPointerException.class, () -> topicClient.submitMessage((TopicId) null, null, (String)null));
+    }
+}

--- a/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -6,6 +6,7 @@ import com.openelements.hiero.base.FungibleTokenClient;
 import com.openelements.hiero.base.HieroContext;
 import com.openelements.hiero.base.NftClient;
 import com.openelements.hiero.base.SmartContractClient;
+import com.openelements.hiero.base.TopicClient;
 import com.openelements.hiero.base.config.HieroConfig;
 import com.openelements.hiero.base.implementation.AccountClientImpl;
 import com.openelements.hiero.base.implementation.AccountRepositoryImpl;
@@ -13,6 +14,7 @@ import com.openelements.hiero.base.implementation.FileClientImpl;
 import com.openelements.hiero.base.implementation.FungibleTokenClientImpl;
 import com.openelements.hiero.base.implementation.NetworkRepositoryImpl;
 import com.openelements.hiero.base.implementation.NftClientImpl;
+import com.openelements.hiero.base.implementation.TopicClientImpl;
 import com.openelements.hiero.base.implementation.NftRepositoryImpl;
 import com.openelements.hiero.base.implementation.ProtocolLayerClientImpl;
 import com.openelements.hiero.base.implementation.SmartContractClientImpl;
@@ -82,6 +84,11 @@ public class HieroAutoConfiguration {
     @Bean
     FungibleTokenClient tokenClient(final ProtocolLayerClient protocolLayerClient, HieroContext hieroContext) {
         return new FungibleTokenClientImpl(protocolLayerClient, hieroContext.getOperatorAccount());
+    }
+
+    @Bean
+    TopicClient topicClient(final ProtocolLayerClient protocolLayerClient, HieroContext hieroContext) {
+        return new TopicClientImpl(protocolLayerClient, hieroContext.getOperatorAccount());
     }
 
     @Bean

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/TopicClientTest.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/TopicClientTest.java
@@ -1,0 +1,201 @@
+package com.openelements.hiero.spring.test;
+
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.openelements.hiero.base.HieroException;
+import com.openelements.hiero.base.TopicClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = TestConfig.class)
+public class TopicClientTest {
+    @Autowired
+    private TopicClient topicClient;
+
+    @Test
+    void testCreateTopic() throws HieroException {
+        final TopicId topicId = topicClient.createTopic();
+        Assertions.assertNotNull(topicId);
+    }
+
+    @Test
+    void testCreatePrivateTopic() throws HieroException {
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createPrivateTopic(submitKey);
+        Assertions.assertNotNull(topicId);
+    }
+
+    @Test
+    void testDeleteTopic() throws HieroException {
+        final TopicId topicId = topicClient.createTopic();
+        Assertions.assertDoesNotThrow(() -> topicClient.deleteTopic(topicId));
+    }
+
+    @Test
+    void testDeleteTopicThrowExceptionFroInvalidId() {
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        Assertions.assertThrows(HieroException.class, () -> topicClient.deleteTopic(topicId));
+    }
+
+    @Test
+    void testDeleteTopicForGivenAdminKey() throws HieroException {
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createTopic(adminKey);
+        Assertions.assertDoesNotThrow(() -> topicClient.deleteTopic(topicId, adminKey));
+    }
+
+    @Test
+    void testDeleteTopicThrowExceptionForDifferentAdminKey() throws HieroException {
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createTopic(adminKey);
+
+        // operatorAccount privateKey will use as adminKey by default
+        Assertions.assertThrows(
+                HieroException.class,
+                () -> topicClient.deleteTopic(topicId)
+        );
+    }
+
+    @Test
+    void testUpdateTopic() throws HieroException {
+        final TopicId topicId = topicClient.createTopic("Hello Hiero");
+        final String updatedMemo = "Updated Hello Hiero";
+        Assertions.assertDoesNotThrow(() -> topicClient.updateTopic(topicId, updatedMemo));
+    }
+
+    @Test
+    void testUpdateTopicThrowExceptionFroInvalidId() {
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final String updatedMemo = "Updated Hello Hiero";
+        Assertions.assertThrows(HieroException.class, () -> topicClient.updateTopic(topicId, updatedMemo));
+    }
+
+    @Test
+    void testUpdateTopicForGivenAdminKey() throws HieroException {
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createTopic(adminKey, "Hello Hiero");
+        final String updatedMemo = "Updated Hello Hiero";
+        Assertions.assertDoesNotThrow(() -> topicClient.updateTopic(topicId, adminKey, updatedMemo));
+    }
+
+    @Test
+    void testUpdateTopicThrowExceptionForDifferentAdminKey() throws HieroException {
+        final PrivateKey adminKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createTopic(adminKey, "Hello Hiero");
+        final String updatedMemo = "Updated Hello Hiero";
+
+        // operatorAccount privateKey will use as adminKey by default
+        Assertions.assertThrows(
+                HieroException.class,
+                () -> topicClient.updateTopic(topicId, updatedMemo)
+        );
+    }
+
+    @Test
+    void testUpdateAdminKey() throws HieroException {
+        final PrivateKey updatedAdminKey = PrivateKey.generateECDSA();
+
+        // operatorAccount privateKey will use as adminKey by default
+        final TopicId topicId = topicClient.createTopic();
+        Assertions.assertDoesNotThrow(() -> topicClient.updateAdminKey(topicId, updatedAdminKey));
+
+        // to verify if adminKey is updated
+        Assertions.assertThrows(HieroException.class, () -> topicClient.deleteTopic(topicId));
+        Assertions.assertDoesNotThrow(() -> topicClient.deleteTopic(topicId, updatedAdminKey));
+    }
+
+    @Test
+    void testUpdateAdminKeyThrowExceptionFroInvalidId() {
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey updatedAdminKey = PrivateKey.generateECDSA();
+        Assertions.assertThrows(HieroException.class, () -> topicClient.updateAdminKey(topicId, updatedAdminKey));
+    }
+
+    @Test
+    void testUpdateSubmitKey() throws HieroException {
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createPrivateTopic(submitKey);
+
+        final PrivateKey updatedSubmitKey = PrivateKey.generateECDSA();
+        Assertions.assertDoesNotThrow(() -> topicClient.updateSubmitKey(topicId, updatedSubmitKey));
+
+        // to verify if submitKey is updated
+        final byte[] message = "Hello Hiero".getBytes();
+        Assertions.assertThrows(HieroException.class, () -> topicClient.submitMessage(topicId, submitKey, message));
+        Assertions.assertDoesNotThrow(() -> topicClient.submitMessage(topicId, updatedSubmitKey, message));
+    }
+
+    @Test
+    void testUpdateSubmitKeyForPublicTopic() throws HieroException {
+        final TopicId topicId = topicClient.createTopic();
+
+        final PrivateKey updatedSubmitKey = PrivateKey.generateECDSA();
+        Assertions.assertDoesNotThrow(() -> topicClient.updateSubmitKey(topicId, updatedSubmitKey));
+
+        // to verify if submitKey is updated
+        final byte[] message = "Hello Hiero".getBytes();
+        Assertions.assertThrows(HieroException.class, () -> topicClient.submitMessage(topicId, message));
+        Assertions.assertDoesNotThrow(() -> topicClient.submitMessage(topicId, updatedSubmitKey, message));
+    }
+
+    @Test
+    void testUpdateSubmitKeyThrowExceptionFroInvalidId() {
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        Assertions.assertThrows(HieroException.class, () -> topicClient.updateSubmitKey(topicId, submitKey));
+    }
+
+    @Test
+    void testSubmitMessage() throws HieroException {
+        final TopicId topicId = topicClient.createTopic();
+        final byte[] message = "Hello Hiero".getBytes();
+        Assertions.assertDoesNotThrow(() -> topicClient.submitMessage(topicId, message));
+    }
+
+    @Test
+    void testSubmitMessageGreaterThanMaxLength() throws HieroException {
+        final TopicId topicId = topicClient.createTopic();
+        final byte[] message = new byte[1025];
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> topicClient.submitMessage(topicId, message)
+        );
+    }
+
+    @Test
+    void testSubmitMessageToPrivateTopic() throws HieroException {
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createPrivateTopic(submitKey);
+        final byte[] message = "Hello Hiero".getBytes();
+        Assertions.assertDoesNotThrow(() -> topicClient.submitMessage(topicId, submitKey, message));
+    }
+
+    @Test
+    void testSubmitMessageToPrivateTopicThrowExceptionIfSubmitKeyMissing() throws HieroException {
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createPrivateTopic(submitKey);
+        final byte[] message = "Hello Hiero".getBytes();
+        Assertions.assertThrows(HieroException.class, () -> topicClient.submitMessage(topicId, message));
+    }
+
+    @Test
+    void testSubmitMessageToPrivateTopicThrowExceptionForInvalidSubmitKey() throws HieroException {
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        final TopicId topicId = topicClient.createPrivateTopic(submitKey);
+        final byte[] message = "Hello Hiero".getBytes();
+        Assertions.assertThrows(
+                HieroException.class,
+                () -> topicClient.submitMessage(topicId, PrivateKey.generateECDSA(), message)
+        );
+    }
+
+    @Test
+    void testSubmitMessageThrowExceptionFroInvalidId() {
+        final TopicId topicId = TopicId.fromString("1.2.3");
+        final byte[] message = "Hello Hiero".getBytes();
+        final PrivateKey submitKey = PrivateKey.generateECDSA();
+        Assertions.assertThrows(HieroException.class, () -> topicClient.submitMessage(topicId, submitKey, message));
+    }
+ }


### PR DESCRIPTION
This pull request introduces the `TopicClient` interface and its implementation for interacting with the Topics on Hedera Network

**Key Features Implemented:**
- createTopic()
- createPrivateTopic()
- updateTopic()
- updateAdminKey()
- updateSubmitKey()
- deleteTopic()
- submitMessage()

Closes: #159 