### PR TITLE
feat: Implement dissociateNft/Token and multi-token association

### DIFF
--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/FungibleTokenClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/FungibleTokenClient.java
@@ -4,6 +4,8 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.TokenId;
 import com.openelements.hiero.base.data.Account;
+
+import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
@@ -229,6 +231,69 @@ public interface FungibleTokenClient {
         Objects.requireNonNull(account, "account must not be null");
         associateToken(tokenId, account.accountId(), account.privateKey());
     }
+
+    /**
+     * Dissociate an account with token.
+     *
+     * @param tokenId the ID of the token
+     * @param accountId the accountId
+     * @param accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the token
+     */
+    void dissociateToken(@NonNull TokenId tokenId, @NonNull AccountId accountId, @NonNull PrivateKey accountKey)
+            throws HieroException;
+
+    /**
+     * Dissociate an account with token.
+     *
+     * @param tokenId the ID of the token
+     * @param accountId the accountId
+     * @param accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the token
+     */
+    default void dissociateToken(@NonNull String tokenId, @NonNull String accountId, @NonNull String accountKey)
+            throws HieroException {
+        Objects.requireNonNull(tokenId, "tokenId must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        dissociateToken(TokenId.fromString(tokenId), AccountId.fromString(accountId), PrivateKey.fromString(accountKey));
+    };
+
+    /**
+     * Dissociate an account with token.
+     *
+     * @param tokenId the ID of the token
+     * @param account the account
+     * @throws HieroException if the account could not be associated with the token
+     */
+    default void dissociateToken(@NonNull TokenId tokenId, @NonNull Account account) throws HieroException {
+        Objects.requireNonNull(account, "accountId must not be null");
+        dissociateToken(tokenId, account.accountId(), account.privateKey());
+    };
+
+    /**
+     * Dissociate an account with token.
+     *
+     * @param tokenIds list of the ID of the token
+     * @param accountId the accountId
+     * @param  accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the token
+     */
+    void dissociateToken(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey)
+            throws HieroException;
+
+    /**
+     * Dissociate an account with token.
+     *
+     * @param tokenIds list of the ID of the token
+     * @param account the account
+     * @throws HieroException if the account could not be associated with the token
+     */
+    default void dissociateToken(@NonNull List<TokenId> tokenIds, @NonNull Account account) throws HieroException {
+        Objects.requireNonNull(account, "accountId must not be null");
+        dissociateToken(tokenIds, account.accountId(), account.privateKey());
+    };
+
 
     /**
      * Mint a Token.

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/FungibleTokenClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/FungibleTokenClient.java
@@ -233,6 +233,29 @@ public interface FungibleTokenClient {
     }
 
     /**
+     * Associate an account with token.
+     *
+     * @param tokenIds list of the ID of the token
+     * @param accountId the accountId
+     * @param  accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the token
+     */
+    void associateToken(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey)
+            throws HieroException;
+
+    /**
+     * Associate an account with token.
+     *
+     * @param tokenIds list of the ID of the token
+     * @param account the account
+     * @throws HieroException if the account could not be associated with the token
+     */
+    default void associateToken(@NonNull List<TokenId> tokenIds, @NonNull Account account) throws HieroException {
+        Objects.requireNonNull(account, "accountId must not be null");
+        associateToken(tokenIds, account.accountId(), account.privateKey());
+    };
+
+    /**
      * Dissociate an account with token.
      *
      * @param tokenId the ID of the token
@@ -293,7 +316,6 @@ public interface FungibleTokenClient {
         Objects.requireNonNull(account, "accountId must not be null");
         dissociateToken(tokenIds, account.accountId(), account.privateKey());
     };
-
 
     /**
      * Mint a Token.

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/NftClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/NftClient.java
@@ -7,6 +7,8 @@ import com.openelements.hiero.base.data.Account;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
+import com.openelements.hiero.base.data.Token;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -202,6 +204,68 @@ public interface NftClient {
         Objects.requireNonNull(account, "account must not be null");
         associateNft(tokenId, account.accountId(), account.privateKey());
     }
+
+    /**
+     * Dissociate an account with an NFT type.
+     *
+     * @param tokenId the ID of the NFT type
+     * @param accountId the  accountId
+     * @param accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the NFT type
+     */
+    void dissociateNft(@NonNull TokenId tokenId, @NonNull AccountId accountId, @NonNull PrivateKey accountKey)
+            throws HieroException;
+
+    /**
+     * Dissociate an account with an NFT type.
+     *
+     * @param tokenId the ID of the NFT type
+     * @param accountId the  accountId
+     * @param accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the NFT type
+     */
+    default void dissociateNft(@NonNull String tokenId, @NonNull String accountId, @NonNull String accountKey)
+            throws HieroException {
+        Objects.requireNonNull(tokenId, "tokenId must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        dissociateNft(TokenId.fromString(tokenId), AccountId.fromString(accountId), PrivateKey.fromString(accountKey));
+    };
+
+    /**
+     * Dissociate an account with an NFT type.
+     *
+     * @param tokenId the ID of the NFT type
+     * @param account the  account
+     * @throws HieroException if the account could not be associated with the NFT type
+     */
+    default void dissociateNft(@NonNull TokenId tokenId, @NonNull Account account) throws HieroException {
+        Objects.requireNonNull(account, "accountId must not be null");
+        dissociateNft(tokenId, account.accountId(), account.privateKey());
+    };
+
+    /**
+     * Dissociate an account with an NFT type.
+     *
+     * @param tokenIds the List of ID for NFT type
+     * @param accountId the  accountId
+     * @param accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the NFT type
+     */
+    void dissociateNft(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey)
+            throws HieroException;
+
+    /**
+     * Dissociate an account with an NFT type.
+     *
+     * @param tokenIds the List of ID for NFT type
+     * @param account the  account
+     * @throws HieroException if the account could not be associated with the NFT type
+     */
+    default void dissociateNft(@NonNull List<TokenId> tokenIds, @NonNull Account account) throws HieroException {
+        Objects.requireNonNull(account, "accountId must not be null");
+        dissociateNft(tokenIds, account.accountId(), account.privateKey());
+    };
 
     /**
      * Mint a new NFT of the given type. The NFT is minted by the operator account. The operator account is used as

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/NftClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/NftClient.java
@@ -206,6 +206,31 @@ public interface NftClient {
     }
 
     /**
+     * Associate an account with an NFT type. If an account is associated with an NFT type, the account can hold NFTs of
+     * that type. Otherwise, the account cannot hold NFTs of that type and tranfer NFTs of that type will fail.
+     *
+     * @param tokenIds the List of ID for NFT type
+     * @param accountId the  accountId
+     * @param accountKey the account privateKey
+     * @throws HieroException if the account could not be associated with the NFT type
+     */
+    void associateNft(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey)
+            throws HieroException;
+
+    /**
+     * Associate an account with an NFT type. If an account is associated with an NFT type, the account can hold NFTs of
+     * that type. Otherwise, the account cannot hold NFTs of that type and tranfer NFTs of that type will fail.
+     *
+     * @param tokenIds the List of ID for NFT type
+     * @param account the  account
+     * @throws HieroException if the account could not be associated with the NFT type
+     */
+    default void associateNft(@NonNull List<TokenId> tokenIds, @NonNull Account account) throws HieroException {
+        Objects.requireNonNull(account, "accountId must not be null");
+        associateNft(tokenIds, account.accountId(), account.privateKey());
+    };
+
+    /**
      * Dissociate an account with an NFT type.
      *
      * @param tokenId the ID of the NFT type

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FungibleTokenClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FungibleTokenClientImpl.java
@@ -68,6 +68,18 @@ public class FungibleTokenClientImpl implements FungibleTokenClient {
     }
 
     @Override
+    public void associateToken(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
+        Objects.requireNonNull(tokenIds, "tokenIds must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        if (tokenIds.isEmpty()) {
+            throw new IllegalArgumentException("tokenIds must not be empty");
+        }
+        final TokenAssociateRequest request = TokenAssociateRequest.of(tokenIds, accountId, accountKey);
+        client.executeTokenAssociateTransaction(request);
+    }
+
+    @Override
     public void dissociateToken(@NonNull TokenId tokenId, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
         Objects.requireNonNull(tokenId, "tokenId must not be null");
         Objects.requireNonNull(accountId, "accountId must not be null");

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FungibleTokenClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/FungibleTokenClientImpl.java
@@ -7,8 +7,9 @@ import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TokenType;
 import com.openelements.hiero.base.HieroException;
 import com.openelements.hiero.base.data.Account;
-import com.openelements.hiero.base.protocol.*;
+import com.openelements.hiero.base.protocol.ProtocolLayerClient;
 import com.openelements.hiero.base.protocol.data.TokenAssociateRequest;
+import com.openelements.hiero.base.protocol.data.TokenDissociateRequest;
 import com.openelements.hiero.base.protocol.data.TokenBurnRequest;
 import com.openelements.hiero.base.protocol.data.TokenBurnResult;
 import com.openelements.hiero.base.protocol.data.TokenCreateRequest;
@@ -18,6 +19,7 @@ import com.openelements.hiero.base.protocol.data.TokenMintResult;
 import com.openelements.hiero.base.protocol.data.TokenTransferRequest;
 import org.jspecify.annotations.NonNull;
 
+import java.util.List;
 import java.util.Objects;
 
 public class FungibleTokenClientImpl implements FungibleTokenClient {
@@ -63,6 +65,27 @@ public class FungibleTokenClientImpl implements FungibleTokenClient {
             throws HieroException {
         final TokenAssociateRequest request = TokenAssociateRequest.of(tokenId, accountId, accountKey);
         client.executeTokenAssociateTransaction(request);
+    }
+
+    @Override
+    public void dissociateToken(@NonNull TokenId tokenId, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
+        Objects.requireNonNull(tokenId, "tokenId must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        final TokenDissociateRequest request = TokenDissociateRequest.of(tokenId, accountId, accountKey);
+        client.executeTokenDissociateTransaction(request);
+    }
+
+    @Override
+    public void dissociateToken(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
+        Objects.requireNonNull(tokenIds, "tokenIds must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        if (tokenIds.isEmpty()) {
+            throw new IllegalArgumentException("tokenIds must not be empty");
+        }
+        final TokenDissociateRequest request = TokenDissociateRequest.of(tokenIds, accountId, accountKey);
+        client.executeTokenDissociateTransaction(request);
     }
 
     @Override

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/NftClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/NftClientImpl.java
@@ -9,6 +9,7 @@ import com.openelements.hiero.base.HieroException;
 import com.openelements.hiero.base.NftClient;
 import com.openelements.hiero.base.protocol.ProtocolLayerClient;
 import com.openelements.hiero.base.protocol.data.TokenAssociateRequest;
+import com.openelements.hiero.base.protocol.data.TokenDissociateRequest;
 import com.openelements.hiero.base.protocol.data.TokenBurnRequest;
 import com.openelements.hiero.base.protocol.data.TokenCreateRequest;
 import com.openelements.hiero.base.protocol.data.TokenCreateResult;
@@ -65,6 +66,27 @@ public class NftClientImpl implements NftClient {
             @NonNull final PrivateKey accountKey) throws HieroException {
         final TokenAssociateRequest request = TokenAssociateRequest.of(tokenId, accountId, accountKey);
         client.executeTokenAssociateTransaction(request);
+    }
+
+    @Override
+    public void dissociateNft(@NonNull TokenId tokenId, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
+        Objects.requireNonNull(tokenId, "tokenId must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        final TokenDissociateRequest request = TokenDissociateRequest.of(tokenId, accountId, accountKey);
+        client.executeTokenDissociateTransaction(request);
+    }
+
+    @Override
+    public void dissociateNft(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
+        Objects.requireNonNull(tokenIds, "tokenIds must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        if (tokenIds.isEmpty()) {
+            throw new IllegalArgumentException("tokenIds must not be empty");
+        }
+        final TokenDissociateRequest request = TokenDissociateRequest.of(tokenIds, accountId, accountKey);
+        client.executeTokenDissociateTransaction(request);
     }
 
     @Override

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/NftClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/NftClientImpl.java
@@ -69,6 +69,18 @@ public class NftClientImpl implements NftClient {
     }
 
     @Override
+    public void associateNft(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
+        Objects.requireNonNull(tokenIds, "tokenIds must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+        if (tokenIds.isEmpty()) {
+            throw new IllegalArgumentException("tokenIds must not be empty");
+        }
+        final TokenAssociateRequest request = TokenAssociateRequest.of(tokenIds, accountId, accountKey);
+        client.executeTokenAssociateTransaction(request);
+    }
+
+    @Override
     public void dissociateNft(@NonNull TokenId tokenId, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) throws HieroException {
         Objects.requireNonNull(tokenId, "tokenId must not be null");
         Objects.requireNonNull(accountId, "accountId must not be null");

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/ProtocolLayerClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/ProtocolLayerClientImpl.java
@@ -23,6 +23,7 @@ import com.hedera.hashgraph.sdk.PublicKey;
 import com.hedera.hashgraph.sdk.Query;
 import com.hedera.hashgraph.sdk.SubscriptionHandle;
 import com.hedera.hashgraph.sdk.TokenAssociateTransaction;
+import com.hedera.hashgraph.sdk.TokenDissociateTransaction;
 import com.hedera.hashgraph.sdk.TokenBurnTransaction;
 import com.hedera.hashgraph.sdk.TokenCreateTransaction;
 import com.hedera.hashgraph.sdk.TokenMintTransaction;
@@ -67,6 +68,8 @@ import com.openelements.hiero.base.protocol.data.FileUpdateResult;
 import com.openelements.hiero.base.protocol.ProtocolLayerClient;
 import com.openelements.hiero.base.protocol.data.TokenAssociateRequest;
 import com.openelements.hiero.base.protocol.data.TokenAssociateResult;
+import com.openelements.hiero.base.protocol.data.TokenDissociateRequest;
+import com.openelements.hiero.base.protocol.data.TokenDissociateResult;
 import com.openelements.hiero.base.protocol.data.TokenBurnRequest;
 import com.openelements.hiero.base.protocol.data.TokenBurnResult;
 import com.openelements.hiero.base.protocol.data.TokenCreateRequest;
@@ -459,6 +462,24 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
             return new TokenAssociateResult(receipt.transactionId, receipt.status);
         } catch (final Exception e) {
             throw new HieroException("Failed to execute associate token transaction", e);
+        }
+    }
+
+    @Override
+    public @NonNull TokenDissociateResult executeTokenDissociateTransaction(@NonNull TokenDissociateRequest request)
+            throws HieroException {
+        Objects.requireNonNull(request, "request must not be null");
+        try {
+            final TokenDissociateTransaction transaction = new TokenDissociateTransaction()
+                    .setMaxTransactionFee(request.maxTransactionFee())
+                    .setTransactionValidDuration(request.transactionValidDuration())
+                    .setAccountId(request.accountId())
+                    .setTokenIds(request.tokenIds());
+            sign(transaction, request.accountKey());
+            final TransactionReceipt receipt = executeTransactionAndWaitOnReceipt(transaction);
+            return new TokenDissociateResult(receipt.transactionId, receipt.status);
+        } catch (final Exception e) {
+            throw new HieroException("Failed to execute dissociate token transaction", e);
         }
     }
 

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/ProtocolLayerClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/ProtocolLayerClientImpl.java
@@ -455,7 +455,7 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
             final TokenAssociateTransaction transaction = new TokenAssociateTransaction()
                     .setMaxTransactionFee(request.maxTransactionFee())
                     .setTransactionValidDuration(request.transactionValidDuration())
-                    .setTokenIds(List.of(request.tokenId()))
+                    .setTokenIds(request.tokenIds())
                     .setAccountId(request.accountId());
             sign(transaction, request.accountPrivateKey());
             final TransactionReceipt receipt = executeTransactionAndWaitOnReceipt(transaction);

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/ProtocolLayerClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/ProtocolLayerClient.java
@@ -28,6 +28,8 @@ import com.openelements.hiero.base.protocol.data.FileUpdateRequest;
 import com.openelements.hiero.base.protocol.data.FileUpdateResult;
 import com.openelements.hiero.base.protocol.data.TokenAssociateRequest;
 import com.openelements.hiero.base.protocol.data.TokenAssociateResult;
+import com.openelements.hiero.base.protocol.data.TokenDissociateRequest;
+import com.openelements.hiero.base.protocol.data.TokenDissociateResult;
 import com.openelements.hiero.base.protocol.data.TokenBurnRequest;
 import com.openelements.hiero.base.protocol.data.TokenBurnResult;
 import com.openelements.hiero.base.protocol.data.TokenCreateRequest;
@@ -195,6 +197,17 @@ public interface ProtocolLayerClient {
      */
     @NonNull
     TokenAssociateResult executeTokenAssociateTransaction(@NonNull final TokenAssociateRequest request)
+            throws HieroException;
+
+    /**
+     * Executes a token dissociate transaction.
+     *
+     * @param request the request containing the details of the token dissociate transaction
+     * @return the result of the token dissociate transaction
+     * @throws HieroException if the transaction could not be executed
+     */
+    @NonNull
+    TokenDissociateResult executeTokenDissociateTransaction(@NonNull final TokenDissociateRequest request)
             throws HieroException;
 
     /**

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TokenAssociateRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TokenAssociateRequest.java
@@ -5,25 +5,30 @@ import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.TokenId;
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
 public record TokenAssociateRequest(@NonNull Hbar maxTransactionFee,
                                     @NonNull Duration transactionValidDuration,
-                                    @NonNull TokenId tokenId,
+                                    @NonNull List<TokenId> tokenIds,
                                     @NonNull AccountId accountId,
                                     @NonNull PrivateKey accountPrivateKey) implements TransactionRequest {
 
     public TokenAssociateRequest {
-        Objects.requireNonNull(tokenId, "tokenId must not be null");
-        Objects.requireNonNull(accountId, "newAccountId must not be null");
+        Objects.requireNonNull(tokenIds, "tokenIds must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
         Objects.requireNonNull(accountPrivateKey, "accountPrivateKey must not be null");
     }
 
     public static TokenAssociateRequest of(@NonNull final TokenId tokenId, @NonNull final AccountId accountId,
-            @NonNull final PrivateKey accountPrivateKey) {
-        return new TokenAssociateRequest(TransactionRequest.DEFAULT_MAX_TRANSACTION_FEE,
-                TransactionRequest.DEFAULT_TRANSACTION_VALID_DURATION, tokenId, accountId, accountPrivateKey);
+                                           @NonNull final PrivateKey accountPrivateKey) {
+        return of(List.of(tokenId), accountId, accountPrivateKey);
     }
 
+    public static TokenAssociateRequest of(@NonNull final List<TokenId> tokenIds, @NonNull final AccountId accountId,
+            @NonNull final PrivateKey accountPrivateKey) {
+        return new TokenAssociateRequest(TransactionRequest.DEFAULT_MAX_TRANSACTION_FEE,
+                TransactionRequest.DEFAULT_TRANSACTION_VALID_DURATION, tokenIds, accountId, accountPrivateKey);
+    }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TokenDissociateRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TokenDissociateRequest.java
@@ -1,0 +1,32 @@
+package com.openelements.hiero.base.protocol.data;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TokenId;
+import org.jspecify.annotations.NonNull;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+public record TokenDissociateRequest(@NonNull Hbar maxTransactionFee,
+                                     @NonNull Duration transactionValidDuration,
+                                     @NonNull List<TokenId> tokenIds,
+                                     @NonNull AccountId accountId,
+                                     @NonNull PrivateKey accountKey) implements TransactionRequest {
+    public TokenDissociateRequest {
+        Objects.requireNonNull(tokenIds, "tokenIds must not be null");
+        Objects.requireNonNull(accountId, "accountId must not be null");
+        Objects.requireNonNull(accountKey, "accountKey must not be null");
+    }
+
+    public static TokenDissociateRequest of(@NonNull TokenId tokenId, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) {
+        return of(List.of(tokenId), accountId, accountKey);
+    }
+
+    public static TokenDissociateRequest of(@NonNull List<TokenId> tokenIds, @NonNull AccountId accountId, @NonNull PrivateKey accountKey) {
+        return new TokenDissociateRequest(TransactionRequest.DEFAULT_MAX_TRANSACTION_FEE,
+                TransactionRequest.DEFAULT_TRANSACTION_VALID_DURATION, tokenIds, accountId, accountKey);
+    }
+}

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TokenDissociateResult.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TokenDissociateResult.java
@@ -1,0 +1,15 @@
+package com.openelements.hiero.base.protocol.data;
+
+import com.hedera.hashgraph.sdk.Status;
+import com.hedera.hashgraph.sdk.TransactionId;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public record TokenDissociateResult(@NonNull TransactionId transactionId, @NonNull Status status) implements
+        TransactionResult {
+    public TokenDissociateResult {
+        Objects.requireNonNull(transactionId, "transactionId must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+    }
+}

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FungibleClientImplTest.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/FungibleClientImplTest.java
@@ -1,0 +1,223 @@
+package com.openelements.hiero.base.test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TokenId;
+import com.openelements.hiero.base.HieroException;
+import com.openelements.hiero.base.data.Account;
+import com.openelements.hiero.base.implementation.FungibleTokenClientImpl;
+import com.openelements.hiero.base.protocol.ProtocolLayerClient;
+import com.openelements.hiero.base.protocol.data.TokenAssociateRequest;
+import com.openelements.hiero.base.protocol.data.TokenAssociateResult;
+import com.openelements.hiero.base.protocol.data.TokenDissociateRequest;
+import com.openelements.hiero.base.protocol.data.TokenDissociateResult;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class FungibleClientImplTest {
+    ProtocolLayerClient protocolLayerClient;
+    Account operationalAccount;
+    FungibleTokenClientImpl fungibleClientImpl;
+
+    ArgumentCaptor<TokenAssociateRequest> tokenAssociateCaptor = ArgumentCaptor.forClass(TokenAssociateRequest.class);
+    ArgumentCaptor<TokenDissociateRequest> tokenDissociateCaptor = ArgumentCaptor.forClass(TokenDissociateRequest.class);
+
+    @BeforeEach
+    public void setup() {
+        protocolLayerClient = Mockito.mock(ProtocolLayerClient.class);
+        operationalAccount = Mockito.mock(Account.class);
+        fungibleClientImpl = new FungibleTokenClientImpl(protocolLayerClient, operationalAccount);
+    }
+
+
+    @Test
+    void testAssociateToken() throws HieroException {
+        final TokenAssociateResult tokenAssociateResult = Mockito.mock(TokenAssociateResult.class);
+
+        final TokenId tokenId = TokenId.fromString("1.2.3");
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+
+        when(protocolLayerClient.executeTokenAssociateTransaction(any(TokenAssociateRequest.class)))
+                .thenReturn(tokenAssociateResult);
+
+        fungibleClientImpl.associateToken(tokenId, accountId, accountKey);
+
+        verify(protocolLayerClient, times(1))
+                .executeTokenAssociateTransaction(tokenAssociateCaptor.capture());
+
+        final TokenAssociateRequest request = tokenAssociateCaptor.getValue();
+        Assertions.assertEquals(List.of(tokenId), request.tokenIds());
+        Assertions.assertEquals(accountId, request.accountId());
+        Assertions.assertEquals(accountKey, request.accountPrivateKey());
+    }
+
+    @Test
+    void testAssociateTokenWithAccount() throws HieroException {
+        final TokenAssociateResult tokenAssociateResult = Mockito.mock(TokenAssociateResult.class);
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey privateKey = PrivateKey.generateECDSA();
+        final PublicKey publicKey = privateKey.getPublicKey();
+
+        final TokenId tokenId = TokenId.fromString("1.2.3");
+        final Account account = new Account(accountId, publicKey, privateKey);
+
+        when(protocolLayerClient.executeTokenAssociateTransaction(any(TokenAssociateRequest.class)))
+                .thenReturn(tokenAssociateResult);
+
+        fungibleClientImpl.associateToken(tokenId, account);
+
+        verify(protocolLayerClient, times(1))
+                .executeTokenAssociateTransaction(tokenAssociateCaptor.capture());
+
+        final TokenAssociateRequest request = tokenAssociateCaptor.getValue();
+        Assertions.assertEquals(List.of(tokenId), request.tokenIds());
+        Assertions.assertEquals(accountId, request.accountId());
+        Assertions.assertEquals(privateKey, request.accountPrivateKey());
+    }
+
+    @Test
+    void testAssociateTokenThrowsExceptionForInvalidId() throws HieroException {
+        final TokenId tokenId = TokenId.fromString("1.2.3");
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+        final Account account = new Account(accountId, accountKey.getPublicKey(), accountKey);
+
+        when(protocolLayerClient.executeTokenAssociateTransaction(any(TokenAssociateRequest.class)))
+                .thenThrow(new HieroException("Failed to execute transaction of type TokenAssociateTransaction"));
+
+        Assertions.assertThrows(HieroException.class, () -> fungibleClientImpl.associateToken(tokenId, accountId, accountKey));
+        Assertions.assertThrows(HieroException.class, () -> fungibleClientImpl.associateToken(tokenId, account));
+    }
+
+    @Test
+    void testAssociateTokenNullParam() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> fungibleClientImpl.associateToken((TokenId) null, (AccountId) null, (PrivateKey) null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> fungibleClientImpl.associateToken((TokenId) null, null));
+    }
+
+    @Test
+    void testAssociateTokenWithMultipleToken() throws HieroException {
+        final TokenAssociateResult tokenAssociateResult = Mockito.mock(TokenAssociateResult.class);
+
+        final TokenId tokenId1 = TokenId.fromString("1.2.3");
+        final TokenId tokenId2 = TokenId.fromString("1.2.4");
+
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+
+        when(protocolLayerClient.executeTokenAssociateTransaction(any(TokenAssociateRequest.class)))
+                .thenReturn(tokenAssociateResult);
+
+        fungibleClientImpl.associateToken(List.of(tokenId1, tokenId2), accountId, accountKey);
+
+        verify(protocolLayerClient, times(1))
+                .executeTokenAssociateTransaction(tokenAssociateCaptor.capture());
+
+        final TokenAssociateRequest request = tokenAssociateCaptor.getValue();
+        Assertions.assertEquals(List.of(tokenId1, tokenId2), request.tokenIds());
+        Assertions.assertEquals(accountId, request.accountId());
+        Assertions.assertEquals(accountKey, request.accountPrivateKey());
+    }
+
+    @Test
+    void testAssociateTokenWithMultipleTokenThrowExceptionIfListEmpty() {
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> fungibleClientImpl.associateToken(List.of(), accountId, accountKey));
+        Assertions.assertEquals("tokenIds must not be empty", e.getMessage());
+    }
+
+    @Test
+    void testDissociateToken() throws HieroException {
+        final TokenDissociateResult tokenDissociateResult = Mockito.mock(TokenDissociateResult.class);
+
+        final TokenId tokenId = TokenId.fromString("1.2.3");
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+
+        when(protocolLayerClient.executeTokenDissociateTransaction(any(TokenDissociateRequest.class)))
+                .thenReturn(tokenDissociateResult);
+
+       fungibleClientImpl.dissociateToken(tokenId, accountId, accountKey);
+
+        verify(protocolLayerClient, times(1))
+                .executeTokenDissociateTransaction(tokenDissociateCaptor.capture());
+
+        final TokenDissociateRequest request = tokenDissociateCaptor.getValue();
+        Assertions.assertEquals(List.of(tokenId), request.tokenIds());
+        Assertions.assertEquals(accountId, request.accountId());
+        Assertions.assertEquals(accountKey, request.accountKey());
+    }
+
+    @Test
+    void testDissociateTokenThrowsExceptionForInvalidId() throws HieroException {
+        final TokenId tokenId = TokenId.fromString("1.2.3");
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+        final Account account = new Account(accountId, accountKey.getPublicKey(), accountKey);
+
+        when(protocolLayerClient.executeTokenDissociateTransaction(any(TokenDissociateRequest.class)))
+                .thenThrow(new HieroException("Failed to execute transaction of type TokenDissociateTransaction"));
+
+        Assertions.assertThrows(HieroException.class, () -> fungibleClientImpl.dissociateToken(tokenId, accountId, accountKey));
+        Assertions.assertThrows(HieroException.class, () -> fungibleClientImpl.dissociateToken(tokenId, account));
+    }
+
+    @Test
+    void testDissociateTokenNullParam() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> fungibleClientImpl.dissociateToken((TokenId) null, null, null));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> fungibleClientImpl.dissociateToken((TokenId) null, null));
+    }
+
+    @Test
+    void testDissociateTokenWithMultipleToken() throws HieroException {
+        final TokenDissociateResult tokenDissociateResult = Mockito.mock(TokenDissociateResult.class);
+
+        final TokenId tokenId1 = TokenId.fromString("1.2.3");
+        final TokenId tokenId2 = TokenId.fromString("1.2.4");
+
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+
+        when(protocolLayerClient.executeTokenDissociateTransaction(any(TokenDissociateRequest.class)))
+                .thenReturn(tokenDissociateResult);
+
+        fungibleClientImpl.dissociateToken(List.of(tokenId1, tokenId2), accountId, accountKey);
+
+        verify(protocolLayerClient, times(1))
+                .executeTokenDissociateTransaction(tokenDissociateCaptor.capture());
+
+        final TokenDissociateRequest request = tokenDissociateCaptor.getValue();
+        Assertions.assertEquals(List.of(tokenId1, tokenId2), request.tokenIds());
+        Assertions.assertEquals(accountId, request.accountId());
+        Assertions.assertEquals(accountKey, request.accountKey());
+    }
+
+    @Test
+    void testDissociateTokenWithMultipleTokenThrowExceptionIfListEmpty() {
+        final AccountId accountId = AccountId.fromString("1.2.3");
+        final PrivateKey accountKey = PrivateKey.generateECDSA();
+
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> fungibleClientImpl.dissociateToken(List.of(), accountId, accountKey));
+        Assertions.assertEquals("tokenIds must not be empty", e.getMessage());
+    }
+}

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerClientTests.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerClientTests.java
@@ -49,6 +49,7 @@ public class ProtocolLayerClientTests {
         Assertions.assertThrows(NullPointerException.class, () -> client.executeAccountCreateTransaction(null));
         Assertions.assertThrows(NullPointerException.class, () -> client.executeTokenCreateTransaction(null));
         Assertions.assertThrows(NullPointerException.class, () -> client.executeTokenAssociateTransaction(null));
+        Assertions.assertThrows(NullPointerException.class, () -> client.executeTokenDissociateTransaction(null));
         Assertions.assertThrows(NullPointerException.class, () -> client.executeTopicCreateTransaction(null));
         Assertions.assertThrows(NullPointerException.class, () -> client.executeTopicDeleteTransaction(null));
         Assertions.assertThrows(NullPointerException.class, () -> client.executeTopicMessageSubmitTransaction(null));

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerDataCreationTests.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerDataCreationTests.java
@@ -915,23 +915,25 @@ public class ProtocolLayerDataCreationTests {
         //Given
         final Hbar maxTransactionFee = Hbar.fromTinybars(1000);
         final Duration transactionValidDuration = Duration.ofSeconds(120);
-        final TokenId tokenId = TokenId.fromString("0.0.12345");
+        final TokenId tokenId = TokenId.fromString("0.0.1");
+        final List<TokenId> tokenIds = List.of(TokenId.fromString("0.0.12345"));
         final AccountId accountId = AccountId.fromString("0.0.54321");
         final PrivateKey accountPrivateKey = PrivateKey.generateECDSA();
 
         //Then
         Assertions.assertDoesNotThrow(
-                () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, tokenId, accountId,
+                () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, tokenIds, accountId,
                         accountPrivateKey));
         Assertions.assertDoesNotThrow(() -> TokenAssociateRequest.of(tokenId, accountId, accountPrivateKey));
+        Assertions.assertDoesNotThrow(() -> TokenAssociateRequest.of(tokenIds, accountId, accountPrivateKey));
         Assertions.assertThrows(NullPointerException.class,
                 () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, null, accountId,
                         accountPrivateKey));
         Assertions.assertThrows(NullPointerException.class,
-                () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, tokenId, null,
+                () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, tokenIds, null,
                         accountPrivateKey));
         Assertions.assertThrows(NullPointerException.class,
-                () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, tokenId, accountId, null));
+                () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, tokenIds, accountId, null));
     }
 
     @Test

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerDataCreationTests.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerDataCreationTests.java
@@ -56,6 +56,8 @@ import com.openelements.hiero.base.protocol.data.TopicDeleteRequest;
 import com.openelements.hiero.base.protocol.data.TopicCreateRequest;
 import com.openelements.hiero.base.protocol.data.TopicUpdateRequest;
 import com.openelements.hiero.base.protocol.data.TopicUpdateResult;
+import com.openelements.hiero.base.protocol.data.TokenDissociateRequest;
+import com.openelements.hiero.base.protocol.data.TokenDissociateResult;
 
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
@@ -647,6 +649,18 @@ public class ProtocolLayerDataCreationTests {
     }
 
     @Test
+    public void testTokenDissociateResultCreation() {
+        //Given
+        final TransactionId transactionId = TransactionId.generate(new AccountId(0, 0, 12345));
+        final Status status = Status.SUCCESS;
+
+        //Then
+        Assertions.assertDoesNotThrow(() -> new TokenDissociateResult(transactionId, status));
+        Assertions.assertThrows(NullPointerException.class, () -> new TokenDissociateResult(null, status));
+        Assertions.assertThrows(NullPointerException.class, () -> new TokenDissociateResult(transactionId, null));
+    }
+
+    @Test
     void testFileUpdateResultCreation() {
         //Given
         final TransactionId transactionId = TransactionId.generate(new AccountId(0, 0, 12345));
@@ -918,6 +932,32 @@ public class ProtocolLayerDataCreationTests {
                         accountPrivateKey));
         Assertions.assertThrows(NullPointerException.class,
                 () -> new TokenAssociateRequest(maxTransactionFee, transactionValidDuration, tokenId, accountId, null));
+    }
+
+    @Test
+    void testTokenDissociateRequestCreation() {
+        //Given
+        final Hbar maxTransactionFee = Hbar.fromTinybars(1000);
+        final Duration transactionValidDuration = Duration.ofSeconds(120);
+        final TokenId tokenId = TokenId.fromString("0.0.1");
+        final List<TokenId> tokenIds = List.of(TokenId.fromString("0.0.12345"));
+        final AccountId accountId = AccountId.fromString("0.0.54321");
+        final PrivateKey accountPrivateKey = PrivateKey.generateECDSA();
+
+        //Then
+        Assertions.assertDoesNotThrow(
+                () -> new TokenDissociateRequest(maxTransactionFee, transactionValidDuration, tokenIds, accountId,
+                        accountPrivateKey));
+        Assertions.assertDoesNotThrow(() -> TokenDissociateRequest.of(tokenIds, accountId, accountPrivateKey));
+        Assertions.assertDoesNotThrow(() -> TokenDissociateRequest.of(tokenId, accountId, accountPrivateKey));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new TokenDissociateRequest(maxTransactionFee, transactionValidDuration, null, accountId,
+                        accountPrivateKey));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new TokenDissociateRequest(maxTransactionFee, transactionValidDuration, tokenIds, null,
+                        accountPrivateKey));
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new TokenDissociateRequest(maxTransactionFee, transactionValidDuration, tokenIds, accountId, null));
     }
 
     @Test

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FungibleTokenClientTest.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FungibleTokenClientTest.java
@@ -32,7 +32,7 @@ public class FungibleTokenClientTest {
     }
 
     @Test
-    void associateToken() throws HieroException {
+    void testAssociateToken() throws HieroException {
         final String name = "TOKEN";
         final String symbol = "FT";
         final TokenId tokenId = tokenClient.createToken(name, symbol);
@@ -40,6 +40,51 @@ public class FungibleTokenClientTest {
         final Account account = accountClient.createAccount(1);
 
         Assertions.assertDoesNotThrow(() -> tokenClient.associateToken(tokenId, account));
+    }
+
+    @Test
+    void testAssociateTokenThrowExceptionForInvalidId() throws HieroException {
+        //given
+        final TokenId tokenId = TokenId.fromString("1.2.3");
+        final Account userAccount = accountClient.createAccount(1);
+
+        //then
+        Assertions.assertThrows(HieroException.class,
+                () -> tokenClient.associateToken(tokenId, userAccount.accountId(), userAccount.privateKey()));
+    }
+
+    @Test
+    void testAssociateTokenForNullParam() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> tokenClient.associateToken((TokenId) null, (String)null, null));
+
+        Assertions.assertThrows(NullPointerException.class,
+                () -> tokenClient.associateToken((TokenId) null, null));
+    }
+
+    @Test
+    void testAssociateTokenWithMultipleToken() throws HieroException {
+        final String name = "TOKEN";
+        final String symbol = "FT";
+
+        final TokenId tokenId1 = tokenClient.createToken(name, symbol);
+        final TokenId tokenId2 = tokenClient.createToken(name, symbol);
+        final Account account = accountClient.createAccount(1);
+
+        Assertions.assertDoesNotThrow(() -> tokenClient.associateToken(List.of(tokenId1, tokenId2), account));
+    }
+
+    @Test
+    void testAssociateTokenWithMultipleTokenThrowExceptionForEmptyList() throws Exception {
+        //given
+        final String name = "Test NFT";
+        final String symbol = "TST";
+
+        final Account userAccount = accountClient.createAccount(1);
+
+        //then
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> tokenClient.associateToken(List.of(), userAccount.accountId(), userAccount.privateKey()));
     }
 
     @Test

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FungibleTokenClientTest.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/FungibleTokenClientTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+
 @SpringBootTest(classes = TestConfig.class)
 public class FungibleTokenClientTest {
 
@@ -38,6 +40,61 @@ public class FungibleTokenClientTest {
         final Account account = accountClient.createAccount(1);
 
         Assertions.assertDoesNotThrow(() -> tokenClient.associateToken(tokenId, account));
+    }
+
+    @Test
+    void testDissociateToken() throws HieroException {
+        final String name = "TOKEN";
+        final String symbol = "FT";
+        final TokenId tokenId = tokenClient.createToken(name, symbol);
+        final Account account = accountClient.createAccount(1);
+
+        tokenClient.associateToken(tokenId, account);
+
+        Assertions.assertDoesNotThrow(() -> tokenClient.dissociateToken(tokenId, account));
+    }
+
+    @Test
+    void testDissociateTokenThrowExceptionIfTokenNotAssociate() throws HieroException {
+        final String name = "TOKEN";
+        final String symbol = "FT";
+        final TokenId tokenId = tokenClient.createToken(name, symbol);
+        final Account account = accountClient.createAccount(1);
+
+        Assertions.assertThrows(HieroException.class, () -> tokenClient.dissociateToken(tokenId, account));
+    }
+
+    @Test
+    void testDissociateTokenWithMultipleToken() throws HieroException {
+        final String name = "TOKEN";
+        final String symbol = "FT";
+        final TokenId tokenId1 = tokenClient.createToken(name, symbol);
+        final TokenId tokenId2 = tokenClient.createToken(name, symbol);
+        final Account account = accountClient.createAccount(1);
+
+        tokenClient.associateToken(tokenId1, account);
+        tokenClient.associateToken(tokenId2, account);
+
+        Assertions.assertDoesNotThrow(() -> tokenClient.dissociateToken(List.of(tokenId1, tokenId2), account));
+    }
+
+    @Test
+    void testDissociateTokenWithMultipleTokenThrowExceptionIfTokenNotAssociate() throws HieroException {
+        final String name = "TOKEN";
+        final String symbol = "FT";
+        final TokenId tokenId1 = tokenClient.createToken(name, symbol);
+        final TokenId tokenId2 = tokenClient.createToken(name, symbol);
+        final Account account = accountClient.createAccount(1);
+
+        tokenClient.associateToken(tokenId1, account);
+
+        Assertions.assertThrows(HieroException.class, () -> tokenClient.dissociateToken(List.of(tokenId1, tokenId2), account));
+    }
+
+    @Test
+    void testDissociateTokenThrowExceptionIfListEmpty() throws HieroException {
+        final Account account = accountClient.createAccount(1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> tokenClient.dissociateToken(List.of(), account));
     }
 
     @Test

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/NftClientTests.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/NftClientTests.java
@@ -10,6 +10,8 @@ import com.openelements.hiero.base.NftClient;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
+
+import com.openelements.hiero.base.data.Token;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,7 +89,7 @@ public class NftClientTests {
     }
 
     @Test
-    void associateNft() throws Exception {
+    void testAssociateNft() throws Exception {
         //given
         final String name = "Test NFT";
         final String symbol = "TST";
@@ -101,7 +103,7 @@ public class NftClientTests {
     }
 
     @Test
-    void associateNftThrowExceptionForInvalidId() throws HieroException {
+    void testAssociateNftThrowExceptionForInvalidId() throws HieroException {
         //given
         final TokenId tokenId = TokenId.fromString("1.2.3");
         final Account userAccount = accountClient.createAccount(1);
@@ -117,12 +119,40 @@ public class NftClientTests {
                 () -> nftClient.associateNft((TokenId) null, null, null));
 
         Assertions.assertThrows(NullPointerException.class,
-                () -> nftClient.associateNft(null, null));
+                () -> nftClient.associateNft((TokenId) null, null));
     }
 
+    @Test
+    void testAssociateNftWithMultipleToken() throws Exception {
+        //given
+        final String name = "Test NFT";
+        final String symbol = "TST";
+
+        final TokenId tokenId1 = nftClient.createNftType(name, symbol);
+        final TokenId tokenId2 = nftClient.createNftType(name, symbol);
+        final Account userAccount = accountClient.createAccount(1);
+
+        //then
+        Assertions.assertDoesNotThrow(() -> {
+            nftClient.associateNft(List.of(tokenId1, tokenId2), userAccount.accountId(), userAccount.privateKey());
+        });
+    }
 
     @Test
-    void testDissociateToken() throws HieroException {
+    void testAssociateNftWithMultipleTokenThrowExceptionForEmptyList() throws Exception {
+        //given
+        final String name = "Test NFT";
+        final String symbol = "TST";
+
+        final Account userAccount = accountClient.createAccount(1);
+
+        //then
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> nftClient.associateNft(List.of(), userAccount.accountId(), userAccount.privateKey()));
+    }
+
+    @Test
+    void testDissociateNft() throws HieroException {
         final String name = "Test NFT";
         final String symbol = "TST";
         final TokenId tokenId = nftClient.createNftType(name, symbol);
@@ -134,7 +164,7 @@ public class NftClientTests {
     }
 
     @Test
-    void testDissociateTokenThrowExceptionIfTokenNotAssociate() throws HieroException {
+    void testDissociateNftThrowExceptionIfTokenNotAssociate() throws HieroException {
         final String name = "Test NFT";
         final String symbol = "TST";
         final TokenId tokenId = nftClient.createNftType(name, symbol);
@@ -144,7 +174,7 @@ public class NftClientTests {
     }
 
     @Test
-    void testDissociateTokenWithMultipleTokens() throws HieroException {
+    void testDissociateNftWithMultipleTokens() throws HieroException {
         final String name = "Test NFT";
         final String symbol = "TST";
         final TokenId tokenId1 = nftClient.createNftType(name, symbol);
@@ -159,7 +189,7 @@ public class NftClientTests {
     }
 
     @Test
-    void testDissociateTokenWithMultipleTokensThrowExceptionIfTokenNotAssociated() throws HieroException {
+    void testDissociateNftWithMultipleTokensThrowExceptionIfTokenNotAssociated() throws HieroException {
         final String name = "Test NFT";
         final String symbol = "TST";
         final TokenId tokenId1 = nftClient.createNftType(name, symbol);
@@ -173,7 +203,7 @@ public class NftClientTests {
     }
 
     @Test
-    void testDissociateTokenThrowExceptionIfListEmpty() throws HieroException {
+    void testDissociateNftThrowExceptionIfListEmpty() throws HieroException {
         final Account account = accountClient.createAccount(1);
         Assertions.assertThrows(IllegalArgumentException.class, () -> nftClient.dissociateNft(List.of(), account));
     }

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/NftClientTests.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/NftClientTests.java
@@ -120,6 +120,64 @@ public class NftClientTests {
                 () -> nftClient.associateNft(null, null));
     }
 
+
+    @Test
+    void testDissociateToken() throws HieroException {
+        final String name = "Test NFT";
+        final String symbol = "TST";
+        final TokenId tokenId = nftClient.createNftType(name, symbol);
+        final Account userAccount = accountClient.createAccount(1);
+
+        nftClient.associateNft(tokenId, userAccount);
+
+        Assertions.assertDoesNotThrow(() -> nftClient.dissociateNft(tokenId, userAccount));
+    }
+
+    @Test
+    void testDissociateTokenThrowExceptionIfTokenNotAssociate() throws HieroException {
+        final String name = "Test NFT";
+        final String symbol = "TST";
+        final TokenId tokenId = nftClient.createNftType(name, symbol);
+        final Account userAccount = accountClient.createAccount(1);
+
+        Assertions.assertThrows(HieroException.class, () -> nftClient.dissociateNft(tokenId, userAccount));
+    }
+
+    @Test
+    void testDissociateTokenWithMultipleTokens() throws HieroException {
+        final String name = "Test NFT";
+        final String symbol = "TST";
+        final TokenId tokenId1 = nftClient.createNftType(name, symbol);
+        final TokenId tokenId2 = nftClient.createNftType(name, symbol);
+
+        final Account userAccount = accountClient.createAccount(1);
+
+        nftClient.associateNft(tokenId1, userAccount);
+        nftClient.associateNft(tokenId2, userAccount);
+
+        Assertions.assertDoesNotThrow(() -> nftClient.dissociateNft(List.of(tokenId1, tokenId2), userAccount));
+    }
+
+    @Test
+    void testDissociateTokenWithMultipleTokensThrowExceptionIfTokenNotAssociated() throws HieroException {
+        final String name = "Test NFT";
+        final String symbol = "TST";
+        final TokenId tokenId1 = nftClient.createNftType(name, symbol);
+        final TokenId tokenId2 = nftClient.createNftType(name, symbol);
+
+        final Account userAccount = accountClient.createAccount(1);
+
+        nftClient.associateNft(tokenId1, userAccount);
+
+        Assertions.assertThrows(HieroException.class, () -> nftClient.dissociateNft(List.of(tokenId1, tokenId2), userAccount));
+    }
+
+    @Test
+    void testDissociateTokenThrowExceptionIfListEmpty() throws HieroException {
+        final Account account = accountClient.createAccount(1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> nftClient.dissociateNft(List.of(), account));
+    }
+
     @Test
     void transferNft() throws Exception {
         //given


### PR DESCRIPTION
This pull request introduce `dissociateNft()` and `dissociateToken()` for `NftClient` and `TokenClient`, along with that it also introduce the functionality to assosiate multiple token with an account.

**Key methods implemented**
- dissociateNft()
- dissociateToken()

Closes: #168 