### PR TITLE
Metrics support for Spring started

### DIFF
--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/interceptors/ReceiveRecordInterceptor.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/interceptors/ReceiveRecordInterceptor.java
@@ -6,14 +6,36 @@ import com.hedera.hashgraph.sdk.TransactionRecord;
 import java.util.Objects;
 import org.jspecify.annotations.NonNull;
 
+/**
+ * First simple interceptor for receiving a record. This interceptor is used to intercept the call for receiving a
+ * record for a transaction. Frameworks like Spring can use this interceptor to add functionalities like metrics,
+ * tracing, or logging to the calls.
+ */
 @FunctionalInterface
 public interface ReceiveRecordInterceptor {
 
+    /**
+     * Default interceptor that does nothing.
+     */
     ReceiveRecordInterceptor DEFAULT_INTERCEPTOR = data -> data.handle();
 
+    /**
+     * Intercept the call for receiving a record for a transaction.
+     *
+     * @param handler the handler that will be used to receive the record
+     * @return the record for the transaction
+     * @throws Exception if the interceptor fails
+     */
     @NonNull
     TransactionRecord getRecordFor(@NonNull ReceiveRecordHandler handler) throws Exception;
 
+    /**
+     * Handler for receiving a record for a transaction.
+     *
+     * @param transaction the transaction for which the record is received
+     * @param receipt     the receipt for the transaction
+     * @param function    the function that will be used to receive the record
+     */
     record ReceiveRecordHandler(@NonNull Transaction transaction, @NonNull TransactionReceipt receipt,
                                 @NonNull ReceiveRecordFunction function) {
 
@@ -23,14 +45,31 @@ public interface ReceiveRecordInterceptor {
             Objects.requireNonNull(function, "handler must not be null");
         }
 
+        /**
+         * Handle the call for receiving a record for a transaction.
+         *
+         * @return the record for the transaction
+         * @throws Exception if the interceptor fails
+         */
         @NonNull
         public TransactionRecord handle() throws Exception {
             return function.handle(receipt);
         }
     }
 
+    /**
+     * Function that will be used to receive the record for a transaction.
+     */
     @FunctionalInterface
     interface ReceiveRecordFunction {
+
+        /**
+         * Handle the call for receiving a record for a transaction.
+         *
+         * @param receipt the receipt for the transaction
+         * @return the record for the transaction
+         * @throws Exception if the interceptor fails
+         */
         @NonNull
         TransactionRecord handle(@NonNull TransactionReceipt receipt) throws Exception;
     }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/interceptors/ReceiveRecordInterceptor.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/interceptors/ReceiveRecordInterceptor.java
@@ -1,0 +1,37 @@
+package com.openelements.hiero.base.interceptors;
+
+import com.hedera.hashgraph.sdk.Transaction;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
+import com.hedera.hashgraph.sdk.TransactionRecord;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+
+@FunctionalInterface
+public interface ReceiveRecordInterceptor {
+
+    ReceiveRecordInterceptor DEFAULT_INTERCEPTOR = data -> data.handle();
+
+    @NonNull
+    TransactionRecord getRecordFor(@NonNull ReceiveRecordHandler handler) throws Exception;
+
+    record ReceiveRecordHandler(@NonNull Transaction transaction, @NonNull TransactionReceipt receipt,
+                                @NonNull ReceiveRecordFunction function) {
+
+        public ReceiveRecordHandler {
+            Objects.requireNonNull(transaction, "transaction must not be null");
+            Objects.requireNonNull(receipt, "receipt must not be null");
+            Objects.requireNonNull(function, "handler must not be null");
+        }
+
+        @NonNull
+        public TransactionRecord handle() throws Exception {
+            return function.handle(receipt);
+        }
+    }
+
+    @FunctionalInterface
+    interface ReceiveRecordFunction {
+        @NonNull
+        TransactionRecord handle(@NonNull TransactionReceipt receipt) throws Exception;
+    }
+}

--- a/hiero-enterprise-base/src/main/java/module-info.java
+++ b/hiero-enterprise-base/src/main/java/module-info.java
@@ -9,6 +9,7 @@ module com.openelements.hiero.base {
     exports com.openelements.hiero.base.implementation.data to com.openelements.hiero.base.test;
     exports com.openelements.hiero.base.config.implementation;
     exports com.openelements.hiero.base.protocol.data;
+    exports com.openelements.hiero.base.interceptors to com.openelements.hiero.base.test;
 
     uses com.openelements.hiero.base.config.NetworkSettingsProvider;
     provides com.openelements.hiero.base.config.NetworkSettingsProvider with com.openelements.hiero.base.config.hedera.HederaNetworkSettingsProvider;

--- a/hiero-enterprise-spring-sample/pom.xml
+++ b/hiero-enterprise-spring-sample/pom.xml
@@ -23,8 +23,16 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>hiero-enterprise-spring</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/hiero-enterprise-spring-sample/src/main/java/com/openelements/hiero/spring/sample/Application.java
+++ b/hiero-enterprise-spring-sample/src/main/java/com/openelements/hiero/spring/sample/Application.java
@@ -1,12 +1,17 @@
 package com.openelements.hiero.spring.sample;
 
 import com.openelements.hiero.spring.EnableHiero;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 @EnableHiero
 public class Application {
+
+    @Autowired
+    MeterRegistry registry;
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/hiero-enterprise-spring-sample/src/main/resources/application.properties
+++ b/hiero-enterprise-spring-sample/src/main/resources/application.properties
@@ -5,4 +5,5 @@ spring.hiero.network.name=${HEDERA_NETWORK:hedera-testnet}
 logging.level.com.openelements=DEBUG
 logging.pattern.console=%d{HH:mm:ss.SSS} %logger{36} - %msg%n
 server.port=${SERVER_PORT:8080}
+# Needs to be done to activate the actuator endpoints (for metrics)
 management.endpoints.web.exposure.include=*

--- a/hiero-enterprise-spring-sample/src/main/resources/application.properties
+++ b/hiero-enterprise-spring-sample/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.config.import=optional:file:.env[.properties]
-
 spring.hiero.accountId=${HEDERA_ACCOUNT_ID:0.0.123}
 spring.hiero.privateKey=${HEDERA_PRIVATE_KEY}
-spring.hiero.network.name=${HEDERA_NETWORK:testnet}
-
+spring.hiero.network.name=${HEDERA_NETWORK:hedera-testnet}
 logging.level.com.openelements=DEBUG
 logging.pattern.console=%d{HH:mm:ss.SSS} %logger{36} - %msg%n
+server.port=${SERVER_PORT:8080}
+management.endpoints.web.exposure.include=*

--- a/hiero-enterprise-spring/pom.xml
+++ b/hiero-enterprise-spring/pom.xml
@@ -44,6 +44,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>hiero-enterprise-test</artifactId>
       <scope>test</scope>

--- a/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -14,20 +14,21 @@ import com.openelements.hiero.base.implementation.FileClientImpl;
 import com.openelements.hiero.base.implementation.FungibleTokenClientImpl;
 import com.openelements.hiero.base.implementation.NetworkRepositoryImpl;
 import com.openelements.hiero.base.implementation.NftClientImpl;
-import com.openelements.hiero.base.implementation.TopicClientImpl;
 import com.openelements.hiero.base.implementation.NftRepositoryImpl;
-import com.openelements.hiero.base.implementation.TopicRepositoryImpl;
 import com.openelements.hiero.base.implementation.ProtocolLayerClientImpl;
 import com.openelements.hiero.base.implementation.SmartContractClientImpl;
 import com.openelements.hiero.base.implementation.TokenRepositoryImpl;
+import com.openelements.hiero.base.implementation.TopicClientImpl;
+import com.openelements.hiero.base.implementation.TopicRepositoryImpl;
 import com.openelements.hiero.base.implementation.TransactionRepositoryImpl;
+import com.openelements.hiero.base.interceptors.ReceiveRecordInterceptor;
 import com.openelements.hiero.base.mirrornode.AccountRepository;
 import com.openelements.hiero.base.mirrornode.MirrorNodeClient;
 import com.openelements.hiero.base.mirrornode.NetworkRepository;
 import com.openelements.hiero.base.mirrornode.NftRepository;
 import com.openelements.hiero.base.mirrornode.TokenRepository;
-import com.openelements.hiero.base.mirrornode.TransactionRepository;
 import com.openelements.hiero.base.mirrornode.TopicRepository;
+import com.openelements.hiero.base.mirrornode.TransactionRepository;
 import com.openelements.hiero.base.protocol.ProtocolLayerClient;
 import com.openelements.hiero.base.verification.ContractVerificationClient;
 import java.net.URI;
@@ -35,15 +36,19 @@ import java.net.URL;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.context.annotation.ApplicationScope;
 
 @AutoConfiguration
 @EnableConfigurationProperties({HieroProperties.class, HieroNetworkProperties.class})
+@Import({MicrometerSupportConfig.class})
 public class HieroAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(HieroAutoConfiguration.class);
@@ -61,8 +66,13 @@ public class HieroAutoConfiguration {
     }
 
     @Bean
-    ProtocolLayerClient protocolLevelClient(final HieroContext hieroContext) {
-        return new ProtocolLayerClientImpl(hieroContext);
+    ProtocolLayerClient protocolLevelClient(final HieroContext hieroContext,
+            @Autowired(required = false) final ReceiveRecordInterceptor interceptor) {
+        ProtocolLayerClientImpl protocolLayerClient = new ProtocolLayerClientImpl(hieroContext);
+        if (interceptor != null) {
+            protocolLayerClient.setRecordInterceptor(interceptor);
+        }
+        return protocolLayerClient;
     }
 
     @Bean

--- a/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/MicrometerSupportConfig.java
+++ b/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/MicrometerSupportConfig.java
@@ -1,0 +1,52 @@
+package com.openelements.hiero.spring.implementation;
+
+import com.hedera.hashgraph.sdk.ContractExecuteTransaction;
+import com.hedera.hashgraph.sdk.TransactionRecord;
+import com.openelements.hiero.base.interceptors.ReceiveRecordInterceptor;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import java.util.HashSet;
+import java.util.Set;
+import org.jspecify.annotations.NonNull;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@ConditionalOnProperty(name = "spring.hiero.metrics.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnClass(name = "org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration")
+public class MicrometerSupportConfig {
+
+    public static final String TRANSACTION_TYPE_TAG = "hiero.transaction.record.type";
+    public static final String CONTRACT_ID_TAG = "hiero.transaction.record.contractId";
+    public static final String TIMER_NAME = "hiero.transaction.record.time";
+    public static final String COUNTER_NAME = "hiero.transaction.record";
+
+    @Bean
+    @NonNull
+    public ReceiveRecordInterceptor interceptRecordReceive(@NonNull final MeterRegistry meterRegistry) {
+        return handler -> {
+            final String transactionType = handler.transaction().getClass().getSimpleName();
+            final Set<Tag> tags = new HashSet<>();
+            tags.add(Tag.of(TRANSACTION_TYPE_TAG, transactionType));
+            if (handler.transaction() instanceof ContractExecuteTransaction contractExecuteTransaction) {
+                tags.add(Tag.of(CONTRACT_ID_TAG,
+                        contractExecuteTransaction.getContractId().toString()));
+            }
+            final Timer timer = meterRegistry.timer(TIMER_NAME, tags);
+            final Counter counter = meterRegistry.counter(COUNTER_NAME, tags);
+            return timer.record(() -> {
+                try {
+                    final TransactionRecord transactionRecord = handler.handle();
+                    counter.increment();
+                    return transactionRecord;
+                } catch (Exception e) {
+                    throw new RuntimeException("Error in handling record interceptor", e);
+                }
+            });
+        };
+    }
+}

--- a/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/MicrometerSupportConfig.java
+++ b/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/MicrometerSupportConfig.java
@@ -15,6 +15,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 
+/**
+ * Micrometer support for Hiero. This configuration class is used to create a {@link ReceiveRecordInterceptor} that will
+ * measure metrics for Hiero transactions. The config is only loaded if the {@code spring.hiero.metrics.enabled}
+ * property is set to {@code true} or not set at all. Next to that, the {@code MetricsAutoConfiguration} configuration
+ * must be on the classpath.
+ */
 @AutoConfiguration
 @ConditionalOnProperty(name = "spring.hiero.metrics.enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnClass(name = "org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration")
@@ -25,6 +31,12 @@ public class MicrometerSupportConfig {
     public static final String TIMER_NAME = "hiero.transaction.record.time";
     public static final String COUNTER_NAME = "hiero.transaction.record";
 
+    /**
+     * Creates a {@link ReceiveRecordInterceptor} that will measure metrics for Hiero transactions.
+     *
+     * @param meterRegistry the {@link MeterRegistry} to use for metrics
+     * @return the {@link ReceiveRecordInterceptor} to use for metrics
+     */
     @Bean
     @NonNull
     public ReceiveRecordInterceptor interceptRecordReceive(@NonNull final MeterRegistry meterRegistry) {


### PR DESCRIPTION
Defines a new interceptor api (first draft, not final) and a first bimplementation on top for spring that adds metrics support for transaction calls.