### PR TITLE
feat: Added subscribeTopic method to TopicClient

### DIFF
--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/HieroContext.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/HieroContext.java
@@ -4,6 +4,8 @@ import com.hedera.hashgraph.sdk.Client;
 import com.openelements.hiero.base.data.Account;
 import org.jspecify.annotations.NonNull;
 
+import java.util.Set;
+
 /**
  * Context for a specific Hiero connection to a network.
  */
@@ -25,4 +27,7 @@ public interface HieroContext {
      */
     @NonNull
     Client getClient();
+
+    @NonNull
+    Set<String> getMirrorNodeEndPoint();
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
@@ -328,7 +328,8 @@ public interface TopicClient {
      * @return SubscriptionHandle for the Topic
      * @throws HieroException if Topic could not be subscribed
      */
-    SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription) throws HieroException;
+    SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription)
+            throws HieroException;
 
     /**
      * Subscribe to a Topic
@@ -337,7 +338,32 @@ public interface TopicClient {
      * @return SubscriptionHandle for the Topic
      * @throws HieroException if Topic could not be subscribed
      */
-    default SubscriptionHandle subscribeTopic(@NonNull String topicId, @NonNull Consumer<TopicMessage> subscription) throws HieroException {
+    default SubscriptionHandle subscribeTopic(@NonNull String topicId, @NonNull Consumer<TopicMessage> subscription)
+            throws HieroException {
         return subscribeTopic(TopicId.fromString(topicId), subscription);
+    }
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @param limit the number of message to return
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                      long limit) throws HieroException;
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @param limit the number of message to return
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    default SubscriptionHandle subscribeTopic(@NonNull String topicId, @NonNull Consumer<TopicMessage> subscription,
+                                              long limit) throws HieroException {
+        return subscribeTopic(TopicId.fromString(topicId), subscription, limit);
     }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
@@ -6,6 +6,7 @@ import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.TopicMessage;
 import org.jspecify.annotations.NonNull;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -365,5 +366,61 @@ public interface TopicClient {
     default SubscriptionHandle subscribeTopic(@NonNull String topicId, @NonNull Consumer<TopicMessage> subscription,
                                               long limit) throws HieroException {
         return subscribeTopic(TopicId.fromString(topicId), subscription, limit);
+    }
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @param startTime time to start subscribing to a topic
+     * @param endTime time to stop subscribing to a topic
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                      @NonNull Instant startTime, @NonNull Instant endTime) throws HieroException;
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @param startTime time to start subscribing to a topic
+     * @param endTime time to stop subscribing to a topic
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    default SubscriptionHandle subscribeTopic(@NonNull String topicId, @NonNull Consumer<TopicMessage> subscription,
+                                              @NonNull Instant startTime, @NonNull Instant endTime) throws HieroException {
+        return subscribeTopic(TopicId.fromString(topicId), subscription, startTime, endTime);
+    }
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @param startTime time to start subscribing to a topic
+     * @param endTime time to stop subscribing to a topic
+     * @param limit the number of message to return
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                      @NonNull Instant startTime, @NonNull Instant endTime, long limit)
+            throws HieroException;
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @param startTime time to start subscribing to a topic
+     * @param endTime time to stop subscribing to a topic
+     * @param limit the number of message to return
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    default SubscriptionHandle subscribeTopic(@NonNull String topicId, @NonNull Consumer<TopicMessage> subscription,
+                                              @NonNull Instant startTime, @NonNull Instant endTime, long limit)
+            throws HieroException {
+        return subscribeTopic(TopicId.fromString(topicId), subscription, startTime, endTime, limit);
     }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/TopicClient.java
@@ -1,10 +1,13 @@
 package com.openelements.hiero.base;
 
 import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.SubscriptionHandle;
 import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicMessage;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Interface for interacting with a Hiero network. This interface provides methods for interacting with Hiero Topic,
@@ -317,4 +320,24 @@ public interface TopicClient {
         Objects.requireNonNull(message, "message cannot be null");
         submitMessage(TopicId.fromString(topicId), PrivateKey.fromString(submitKey), message);
     };
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription) throws HieroException;
+
+    /**
+     * Subscribe to a Topic
+     *
+     * @param topicId the topicId of topic
+     * @return SubscriptionHandle for the Topic
+     * @throws HieroException if Topic could not be subscribed
+     */
+    default SubscriptionHandle subscribeTopic(@NonNull String topicId, @NonNull Consumer<TopicMessage> subscription) throws HieroException {
+        return subscribeTopic(TopicId.fromString(topicId), subscription);
+    }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/HieroConfig.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/HieroConfig.java
@@ -41,6 +41,9 @@ public interface HieroConfig {
     @NonNull
     Set<String> getMirrorNodeAddresses();
 
+    @NonNull
+    Set<String> getConsensusServiceAddress();
+
     /**
      * Returns the consensus nodes.
      *
@@ -88,6 +91,11 @@ public interface HieroConfig {
             public @NonNull Client getClient() {
                 return client;
             }
+
+            @Override
+            public @NonNull Set<String> getMirrorNodeEndPoint() {
+                return getMirrorNodeAddresses();
+            }
         };
     }
 
@@ -102,7 +110,7 @@ public interface HieroConfig {
             final Map<String, AccountId> nodes = getConsensusNodes().stream()
                     .collect(Collectors.toMap(n -> n.getAddress(), n -> n.getAccountId()));
             final Client client = Client.forNetwork(nodes);
-            final List<String> mirrorNodeAddresses = getMirrorNodeAddresses().stream().collect(Collectors.toList());
+            final List<String> mirrorNodeAddresses = getConsensusServiceAddress().stream().collect(Collectors.toList());
             client.setMirrorNetwork(mirrorNodeAddresses);
             client.setOperator(getOperatorAccount().accountId(), getOperatorAccount().privateKey());
             getRequestTimeout().ifPresent(client::setRequestTimeout);

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/NetworkSettings.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/NetworkSettings.java
@@ -41,6 +41,14 @@ public interface NetworkSettings {
     Set<String> getMirrorNodeAddresses();
 
     /**
+     * Returns the consensus service address.
+     *
+     * @return the consensus service addresses
+     */
+    @NonNull
+    Set<String> getConsensusServiceAddress();
+
+    /**
      * Returns the consensus nodes.
      *
      * @return the consensus nodes

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/hedera/HederaMainnetSettings.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/hedera/HederaMainnetSettings.java
@@ -32,6 +32,9 @@ public final class HederaMainnetSettings implements NetworkSettings {
     }
 
     @Override
+    public @NonNull Set<String> getConsensusServiceAddress() {return Set.of("mainnet.mirrornode.hedera.com:443");}
+
+    @Override
     public @NonNull Set<ConsensusNode> getConsensusNodes() {
         return Set.of(new ConsensusNode("35.186.191.247", "50211", "0.0.4"));
     }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/hedera/HederaTestnetSettings.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/config/hedera/HederaTestnetSettings.java
@@ -32,6 +32,9 @@ public final class HederaTestnetSettings implements NetworkSettings {
     }
 
     @Override
+    public @NonNull Set<String> getConsensusServiceAddress() {return Set.of("testnet.mirrornode.hedera.com:443");}
+
+    @Override
     public @NonNull Set<ConsensusNode> getConsensusNodes() {
         return Set.of(new ConsensusNode("0.testnet.hedera.com", "50211", "0.0.3"));
     }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/ProtocolLayerClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/ProtocolLayerClientImpl.java
@@ -434,7 +434,7 @@ public class ProtocolLayerClientImpl implements ProtocolLayerClient {
                 query.setLimit(request.limit());
             }
             final SubscriptionHandle subscribe = query.subscribe(hieroContext.getClient(), request.subscription());
-            return new TopicMessageResult();
+            return new TopicMessageResult(subscribe);
         } catch (final Exception e) {
             throw new HieroException("Failed to execute query message transaction", e);
         }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
@@ -1,15 +1,24 @@
 package com.openelements.hiero.base.implementation;
 
 import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.SubscriptionHandle;
 import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicMessage;
 import com.openelements.hiero.base.HieroException;
 import com.openelements.hiero.base.TopicClient;
 import com.openelements.hiero.base.data.Account;
 import com.openelements.hiero.base.protocol.ProtocolLayerClient;
-import com.openelements.hiero.base.protocol.data.*;
+import com.openelements.hiero.base.protocol.data.TopicCreateRequest;
+import com.openelements.hiero.base.protocol.data.TopicCreateResult;
+import com.openelements.hiero.base.protocol.data.TopicUpdateRequest;
+import com.openelements.hiero.base.protocol.data.TopicDeleteRequest;
+import com.openelements.hiero.base.protocol.data.TopicSubmitMessageRequest;
+import com.openelements.hiero.base.protocol.data.TopicMessageRequest;
+import com.openelements.hiero.base.protocol.data.TopicMessageResult;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Objects;
+import java.util.function.Consumer;
 
 public class TopicClientImpl implements TopicClient {
     private final ProtocolLayerClient client;
@@ -107,7 +116,7 @@ public class TopicClientImpl implements TopicClient {
         Objects.requireNonNull(topicId, "topicId must not be null");
         Objects.requireNonNull(submitKey, "submitKey must not be null");
         Objects.requireNonNull(memo, "memo must not be null");
-       updateTopic(topicId, operationalAccount.privateKey(), updatedAdminKey, submitKey, memo);
+        updateTopic(topicId, operationalAccount.privateKey(), updatedAdminKey, submitKey, memo);
     }
 
     @Override
@@ -201,5 +210,15 @@ public class TopicClientImpl implements TopicClient {
         Objects.requireNonNull(message, "message must not be null");
         TopicSubmitMessageRequest request = TopicSubmitMessageRequest.of(topicId, submitKey, message);
         client.executeTopicMessageSubmitTransaction(request);
+    }
+
+    @Override
+    public SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription)
+            throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(subscription, "subscription must not be null");
+        TopicMessageRequest request = TopicMessageRequest.of(topicId, subscription);
+        TopicMessageResult result = client.executeTopicMessageQuery(request);
+        return result.subscriptionHandle();
     }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
@@ -17,6 +17,7 @@ import com.openelements.hiero.base.protocol.data.TopicMessageRequest;
 import com.openelements.hiero.base.protocol.data.TopicMessageResult;
 import org.jspecify.annotations.NonNull;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -232,6 +233,50 @@ public class TopicClientImpl implements TopicClient {
         }
 
         TopicMessageRequest request = TopicMessageRequest.of(topicId, subscription, limit);
+        TopicMessageResult result = client.executeTopicMessageQuery(request);
+        return result.subscriptionHandle();
+    }
+
+    @Override
+    public SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                             Instant startTime, Instant endTime) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(subscription, "subscription must not be null");
+        Objects.requireNonNull(startTime, "startTime must not be null");
+        Objects.requireNonNull(endTime, "endTime must not be null");
+
+        if (startTime.isBefore(Instant.now())) {
+            throw  new IllegalArgumentException("startTime must be greater than currentTime");
+        }
+        if (endTime.isBefore(startTime)) {
+            throw  new IllegalArgumentException("endTime must be greater than starTime");
+        }
+
+        TopicMessageRequest request = TopicMessageRequest.of(topicId, subscription, startTime, endTime);
+        TopicMessageResult result = client.executeTopicMessageQuery(request);
+        return result.subscriptionHandle();
+    }
+
+    @Override
+    public SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                             @NonNull Instant startTime, @NonNull Instant endTime, long limit)
+            throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(subscription, "subscription must not be null");
+        Objects.requireNonNull(startTime, "startTime must not be null");
+        Objects.requireNonNull(endTime, "endTime must not be null");
+
+        if (startTime.isBefore(Instant.now())) {
+            throw  new IllegalArgumentException("startTime must be greater than currentTime");
+        }
+        if (endTime.isBefore(startTime)) {
+            throw  new IllegalArgumentException("endTime must be greater than starTime");
+        }
+        if (limit == 0) {
+            throw new IllegalArgumentException("limit must be greater than 0");
+        }
+
+        TopicMessageRequest request = TopicMessageRequest.of(topicId, subscription, startTime, endTime, limit);
         TopicMessageResult result = client.executeTopicMessageQuery(request);
         return result.subscriptionHandle();
     }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/implementation/TopicClientImpl.java
@@ -221,4 +221,18 @@ public class TopicClientImpl implements TopicClient {
         TopicMessageResult result = client.executeTopicMessageQuery(request);
         return result.subscriptionHandle();
     }
+
+    @Override
+    public SubscriptionHandle subscribeTopic(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                             long limit) throws HieroException {
+        Objects.requireNonNull(topicId, "topicId must not be null");
+        Objects.requireNonNull(subscription, "subscription must not be null");
+        if (limit == 0) {
+            throw new IllegalArgumentException("limit must be greater than 0");
+        }
+
+        TopicMessageRequest request = TopicMessageRequest.of(topicId, subscription, limit);
+        TopicMessageResult result = client.executeTopicMessageQuery(request);
+        return result.subscriptionHandle();
+    }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicMessageRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicMessageRequest.java
@@ -26,4 +26,10 @@ public record TopicMessageRequest(@NonNull TopicId topicId, @NonNull Consumer<To
     public static TopicMessageRequest of(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription) {
         return new TopicMessageRequest(topicId, subscription, null, null, NO_LIMIT, null, null);
     }
+
+    @NonNull
+    public static TopicMessageRequest of(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                         @NonNull long limit) {
+        return new TopicMessageRequest(topicId, subscription, null, null,limit, null, null);
+    }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicMessageRequest.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicMessageRequest.java
@@ -32,4 +32,16 @@ public record TopicMessageRequest(@NonNull TopicId topicId, @NonNull Consumer<To
                                          @NonNull long limit) {
         return new TopicMessageRequest(topicId, subscription, null, null,limit, null, null);
     }
+
+    @NonNull
+    public static TopicMessageRequest of(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                         @NonNull Instant startTime, @NonNull Instant endTime) {
+        return new TopicMessageRequest(topicId, subscription, startTime, endTime, NO_LIMIT, null, null);
+    }
+
+    @NonNull
+    public static TopicMessageRequest of(@NonNull TopicId topicId, @NonNull Consumer<TopicMessage> subscription,
+                                         @NonNull Instant startTime, @NonNull Instant endTime, long limit) {
+        return new TopicMessageRequest(topicId, subscription, startTime, endTime, limit, null, null);
+    }
 }

--- a/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicMessageResult.java
+++ b/hiero-enterprise-base/src/main/java/com/openelements/hiero/base/protocol/data/TopicMessageResult.java
@@ -1,4 +1,14 @@
 package com.openelements.hiero.base.protocol.data;
 
-public record TopicMessageResult() {
+import com.hedera.hashgraph.sdk.Status;
+import com.hedera.hashgraph.sdk.SubscriptionHandle;
+import com.hedera.hashgraph.sdk.TransactionId;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+
+public record TopicMessageResult(@NonNull SubscriptionHandle subscriptionHandle) {
+    public TopicMessageResult {
+        Objects.requireNonNull(subscriptionHandle, "subscriptionHandle must not be null");
+    }
 }

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerClientTests.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/ProtocolLayerClientTests.java
@@ -11,6 +11,8 @@ import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 public class ProtocolLayerClientTests {
 
     @Test
@@ -29,6 +31,11 @@ public class ProtocolLayerClientTests {
 
             @Override
             public @NonNull Client getClient() {
+                return null;
+            }
+
+            @Override
+            public @NonNull Set<String> getMirrorNodeEndPoint() {
                 return null;
             }
         };

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/config/HieroTestContext.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/config/HieroTestContext.java
@@ -11,6 +11,8 @@ import io.github.cdimascio.dotenv.Dotenv;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 
@@ -21,6 +23,8 @@ public class HieroTestContext implements HieroContext {
     private final Account operationalAccount;
 
     private final Client client;
+
+    private final Set<String> mirronNodeEnpoint;
 
     public HieroTestContext() {
         final Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
@@ -57,6 +61,7 @@ public class HieroTestContext implements HieroContext {
         final Map<String, AccountId> nodes = new HashMap<>();
         networkSettings.getConsensusNodes()
                 .forEach(consensusNode -> nodes.put(consensusNode.getAddress(), consensusNode.getAccountId()));
+        mirronNodeEnpoint = networkSettings.getConsensusServiceAddress();
         client = Client.forNetwork(nodes);
         if (!networkSettings.getMirrorNodeAddresses().isEmpty()) {
             try {
@@ -75,5 +80,10 @@ public class HieroTestContext implements HieroContext {
 
     public Client getClient() {
         return client;
+    }
+
+    @Override
+    public @NonNull Set<String> getMirrorNodeEndPoint() {
+        return mirronNodeEnpoint;
     }
 }

--- a/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/config/SoloActionNetworkSettings.java
+++ b/hiero-enterprise-base/src/test/java/com/openelements/hiero/base/test/config/SoloActionNetworkSettings.java
@@ -25,6 +25,9 @@ public class SoloActionNetworkSettings implements NetworkSettings {
     }
 
     @Override
+    public @NonNull Set<String> getConsensusServiceAddress() {return Set.of("http://localhost:8080");}
+
+    @Override
     public @NonNull Set<ConsensusNode> getConsensusNodes() {
         return Set.of(new ConsensusNode("127.0.0.1", "50211", "0.0.3"));
     }

--- a/hiero-enterprise-microprofile/src/main/java/com/openelements/hiero/microprofile/implementation/HieroConfigImpl.java
+++ b/hiero-enterprise-microprofile/src/main/java/com/openelements/hiero/microprofile/implementation/HieroConfigImpl.java
@@ -27,6 +27,8 @@ public class HieroConfigImpl implements HieroConfig {
 
     private final Set<String> mirrorNodeAddresses;
 
+    private final Set<String> consensusServiceAddress;
+
     private final Set<ConsensusNode> consensusNodes;
 
     private final Long chainId;
@@ -51,12 +53,14 @@ public class HieroConfigImpl implements HieroConfig {
             final NetworkSettings settings = networkSettings.get();
             networkName = settings.getNetworkName().orElse(networkConfiguration.getName().orElse(null));
             mirrorNodeAddresses = Collections.unmodifiableSet(settings.getMirrorNodeAddresses());
+            consensusServiceAddress = Collections.unmodifiableSet(settings.getConsensusServiceAddress());
             consensusNodes = Collections.unmodifiableSet(settings.getConsensusNodes());
             chainId = settings.chainId().orElse(null);
             relayUrl = settings.relayUrl().orElse(null);
         } else {
             networkName = networkConfiguration.getName().orElse(null);
             mirrorNodeAddresses = networkConfiguration.getMirrornode().map(Set::of).orElse(Set.of());
+            consensusServiceAddress = Set.of();
             consensusNodes = Collections.unmodifiableSet(networkConfiguration.getNodes());
             chainId = null;
             relayUrl = null;
@@ -81,6 +85,11 @@ public class HieroConfigImpl implements HieroConfig {
     @Override
     public @NonNull Set<String> getMirrorNodeAddresses() {
         return mirrorNodeAddresses;
+    }
+
+    @Override
+    public @NonNull Set<String> getConsensusServiceAddress() {
+        return consensusServiceAddress;
     }
 
     @Override

--- a/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroAutoConfiguration.java
+++ b/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroAutoConfiguration.java
@@ -34,6 +34,8 @@ import com.openelements.hiero.base.verification.ContractVerificationClient;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -110,7 +112,7 @@ public class HieroAutoConfiguration {
             havingValue = "true", matchIfMissing = true)
     MirrorNodeClient mirrorNodeClient(final HieroContext hieroContext) {
         final String mirrorNodeEndpoint;
-        final List<String> mirrorNetwork = hieroContext.getClient().getMirrorNetwork();
+        final List<String> mirrorNetwork = hieroContext.getMirrorNodeEndPoint().stream().toList();
         if (mirrorNetwork.isEmpty()) {
             throw new IllegalArgumentException("Mirror node endpoint must be set");
         }

--- a/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroConfigImpl.java
+++ b/hiero-enterprise-spring/src/main/java/com/openelements/hiero/spring/implementation/HieroConfigImpl.java
@@ -23,6 +23,8 @@ public class HieroConfigImpl implements HieroConfig {
 
     private final Set<String> mirrorNodeAddresses;
 
+    private final Set<String> consensusServiceAddress;
+
     private final Set<ConsensusNode> consensusNodes;
 
     private final Long chainId;
@@ -50,6 +52,7 @@ public class HieroConfigImpl implements HieroConfig {
             final NetworkSettings settings = networkSettings.get();
             networkName = settings.getNetworkName().orElse(properties.getNetwork().getName());
             mirrorNodeAddresses = Collections.unmodifiableSet(settings.getMirrorNodeAddresses());
+            consensusServiceAddress = Collections.unmodifiableSet(settings.getConsensusServiceAddress());
             consensusNodes = Collections.unmodifiableSet(settings.getConsensusNodes());
             chainId = settings.chainId().orElse(null);
             relayUrl = settings.relayUrl().orElse(null);
@@ -61,6 +64,7 @@ public class HieroConfigImpl implements HieroConfig {
             } else {
                 mirrorNodeAddresses = Set.of();
             }
+            consensusServiceAddress = Set.of();
             final List<HieroNode> nodes = properties.getNetwork().getNodes();
             if (nodes == null || nodes.isEmpty()) {
                 consensusNodes = Set.of();
@@ -104,6 +108,11 @@ public class HieroConfigImpl implements HieroConfig {
     @Override
     public Set<String> getMirrorNodeAddresses() {
         return mirrorNodeAddresses;
+    }
+
+    @Override
+    public @NonNull Set<String> getConsensusServiceAddress() {
+        return consensusServiceAddress;
     }
 
     @Override

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/TopicClientTest.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/TopicClientTest.java
@@ -7,10 +7,12 @@ import com.openelements.hiero.base.HieroException;
 import com.openelements.hiero.base.TopicClient;
 import com.openelements.hiero.test.HieroTestUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -262,5 +264,28 @@ public class TopicClientTest {
         ));
 
         Assertions.assertEquals(msg, e.getMessage());
+    }
+
+    @Test
+    @Disabled
+    // To fix
+    void testSubscribeTopicWithStartAndEndTime() throws  HieroException {
+        final TopicId topicId = topicClient.createTopic();
+        hieroTestUtils.waitForMirrorNodeRecords();
+
+        final Instant startTime = Instant.now().plusSeconds(60);
+        final Instant endTime = startTime.plusSeconds(120);
+
+        final List<String> messages = new ArrayList<>();
+
+        final SubscriptionHandle handler = topicClient.subscribeTopic(topicId, (message) -> {
+            messages.add(new String(message.contents));
+        }, startTime, endTime);
+
+        topicClient.submitMessage(topicId, "Hello Hiero");
+        hieroTestUtils.waitForMirrorNodeRecords();
+
+        Assertions.assertNotNull(handler);
+        Assertions.assertEquals(1, messages.size());
     }
 }

--- a/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/TopicClientTest.java
+++ b/hiero-enterprise-spring/src/test/java/com/openelements/hiero/spring/test/TopicClientTest.java
@@ -7,12 +7,10 @@ import com.openelements.hiero.base.HieroException;
 import com.openelements.hiero.base.TopicClient;
 import com.openelements.hiero.test.HieroTestUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -267,25 +265,7 @@ public class TopicClientTest {
     }
 
     @Test
-    @Disabled
-    // To fix
-    void testSubscribeTopicWithStartAndEndTime() throws  HieroException {
-        final TopicId topicId = topicClient.createTopic();
-        hieroTestUtils.waitForMirrorNodeRecords();
-
-        final Instant startTime = Instant.now().plusSeconds(60);
-        final Instant endTime = startTime.plusSeconds(120);
-
-        final List<String> messages = new ArrayList<>();
-
-        final SubscriptionHandle handler = topicClient.subscribeTopic(topicId, (message) -> {
-            messages.add(new String(message.contents));
-        }, startTime, endTime);
-
-        topicClient.submitMessage(topicId, "Hello Hiero");
-        hieroTestUtils.waitForMirrorNodeRecords();
-
-        Assertions.assertNotNull(handler);
-        Assertions.assertEquals(1, messages.size());
+    void testSubscribeTopicWithStartAndEndTime() {
+        //TODO
     }
 }

--- a/hiero-enterprise-test/src/main/java/com/openelements/hiero/test/SoloActionNetworkSettings.java
+++ b/hiero-enterprise-test/src/main/java/com/openelements/hiero/test/SoloActionNetworkSettings.java
@@ -25,6 +25,9 @@ public class SoloActionNetworkSettings implements NetworkSettings {
     }
 
     @Override
+    public @NonNull Set<String> getConsensusServiceAddress() {return Set.of("http://localhost:8080");} //TBD
+
+    @Override
     public @NonNull Set<ConsensusNode> getConsensusNodes() {
         return Set.of(new ConsensusNode("127.0.0.1", "50211", "0.0.3"));
     }


### PR DESCRIPTION
This PR introduces `subscribeTopic()` method to the `TopicClient`  interface, which help to subscribe and listen to the messages received by the specific Hedera Topic.

**Key Changes:**
- Added  `getConsensusServiceAddress` to `NetworkSettings` to store the HCS gRPC API because is because `TopicMessageQuery` uses the gRPC protocol.

**Method Added:**
- subscribeTopic(topicId, consumer)
- subscribeTopic(topicId, consumer, limit)
- subscribeTopic(topicId, consumer, startTime, endTime)
- subscribeTopic(topicId, consumer, limit, startTime, endTime)

Closes: #193 
 